### PR TITLE
fix: improve tree

### DIFF
--- a/src/Bluent.UI/Components/TreeComponent/TreeItem.razor.cs
+++ b/src/Bluent.UI/Components/TreeComponent/TreeItem.razor.cs
@@ -192,7 +192,7 @@ public partial class TreeItem
 
     private async Task SetCheckState(bool? value)
     {
-        if (!DisableCheckBox)
+        if (!DisableCheckBox && IsChecked != value)
         {
             IsChecked = value;
             await IsCheckedChanged.InvokeAsync(IsChecked);


### PR DESCRIPTION
Don't call IsCheckedChanged if the value is not changed.