### PR TITLE
Sprint 2: redesign demo landing and navigation

### DIFF
--- a/.bluent/BACKLOG.md
+++ b/.bluent/BACKLOG.md
@@ -1,0 +1,74 @@
+# Bluent Backlog
+
+This file contains project work that is not fully represented by the active sprint checklist.
+
+Use `.bluent/PROJECT.md` for current status and `.bluent/HANDOFF.md` for the immediate agent handoff.
+
+## Now
+
+Work committed to Sprint 2:
+
+- Complete the demo landing, navigation, component showcase, enterprise scenarios, visual validation, screenshots, and deployment validation tracked by Issue #368 and PR #369.
+- Keep project tracking and validation evidence current.
+
+## Next
+
+Likely Sprint 3 candidates:
+
+- Define and automate a predictable release workflow.
+- Modernize and validate the GitHub Pages/static deployment workflow.
+- Improve release notes and release evidence.
+- Triage and resolve existing compiler warnings before the next stable release.
+- Add accessibility and quality gates where practical.
+- Create contributor-friendly issues and identify good-first-issue candidates.
+
+## Parallel Quality Work
+
+- [Issue #366](https://github.com/vrassouli/Bluent/issues/366): validate Interactive Server, Interactive WebAssembly, and Interactive Auto render modes.
+- Continue [Issue #363](https://github.com/vrassouli/Bluent/issues/363): expand verified component references and compile representative AI-generated consumer samples.
+- Expand the AI benchmark to context-free and multiple-model runs.
+- Add consumer-project build validation for generated examples.
+
+## Later
+
+- Documentation website or GitHub Pages redesign beyond the demo scope.
+- Brand and visual identity refinement.
+- Automated API reference generation.
+- Public application showcase.
+- Community launch and outreach.
+- Package naming and boundary review.
+- Release cadence review.
+- Additional migration guides as public APIs evolve.
+- Evaluate a generated AI context bundle or Bluent MCP after canonical documentation is mature.
+
+## Parking Lot
+
+Ideas that require evaluation before scheduling:
+
+- Searchable component catalog inside the demo.
+- Automated screenshot generation and visual regression testing.
+- Accessibility test automation for selected components.
+- Interactive code playgrounds.
+- Versioned documentation for multiple stable releases.
+- Public compatibility dashboard for render modes and browsers.
+
+## Deferred or Rejected for the Relaunch Phase
+
+- New product components without explicit maintainer approval.
+- Broad public API redesigns.
+- Manufactured popularity or recommendation signals.
+- Claims of support that are not backed by source or runtime evidence.
+- A custom agent skill system before repeatable workflows justify it.
+
+## Backlog Item Template
+
+Use this format when adding actionable work:
+
+```markdown
+- [ ] Item title
+  - Priority: High | Medium | Low
+  - Type: Product | Documentation | Quality | Infrastructure | Community
+  - Tracking: Issue or PR URL when available
+  - Dependencies: Required preceding work
+  - Done when: Observable acceptance criteria
+```

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -1,0 +1,91 @@
+# Codex Handoff
+
+This file is the operational entry point for continuing Bluent with Codex or another coding agent.
+
+## Current Objective
+
+Complete **Sprint 2 — Demo and Visual Presentation**.
+
+The immediate goal is to turn the existing demo into a credible public product experience for developers evaluating Bluent as an enterprise Blazor UI toolkit.
+
+## Current Branch and Tracking
+
+- Branch: `demo/sprint-2-visual-presentation`
+- Pull request: [#369](https://github.com/vrassouli/Bluent/pull/369) — draft
+- Sprint issue: [#368](https://github.com/vrassouli/Bluent/issues/368)
+- AI-readiness epic: [#363](https://github.com/vrassouli/Bluent/issues/363)
+- Demo audit: `docs/demo/sprint-2-audit.md`
+- Sprint plan: `.bluent/sprints/sprint-02.md`
+
+## Read First
+
+1. `AGENTS.md`
+2. `.bluent/PROJECT.md`
+3. this file
+4. `.bluent/sprints/sprint-02.md`
+5. `.bluent/QUALITY.md`
+6. `.bluent/BACKLOG.md`
+7. `docs/demo/sprint-2-audit.md`
+8. `src/Bluent.UI.Demo.Pages/AGENTS.md`
+9. relevant canonical documentation under `docs/`
+
+## Current State
+
+Already implemented on the active branch:
+
+- Product-oriented responsive landing page replacing the default Blazor starter page.
+- In-demo Getting Started page based on canonical documentation.
+- Purpose-based navigation groups.
+- Functional compact and expanded navigation.
+- Initial responsive scoped styling.
+- Successful GitHub Actions restore, Release build, tests, package creation, and Markdown-link validation.
+
+Still required before Sprint 2 can be considered complete:
+
+- Add at least three runnable enterprise scenario pages.
+- Establish and apply a repeatable component showcase layout to the highest-value pages.
+- Perform browser-based desktop and mobile review.
+- Validate light and dark themes.
+- Validate LTR and RTL layouts.
+- Validate Home and Getting Started behavior in a running application.
+- Capture accurate professional screenshots.
+- Validate the static deployment workflow.
+- Update project tracking and PR evidence.
+
+## Execution Order
+
+1. Review the active branch and PR #369 before changing code.
+2. Implement the enterprise scenario pages defined in `.bluent/sprints/sprint-02.md`.
+3. Apply the showcase structure to selected high-value components.
+4. Perform runtime visual validation across required modes and widths.
+5. Fix issues found during validation without expanding into unrelated feature work.
+6. Capture screenshots only from the validated running application.
+7. Run all required build, test, pack, and documentation checks.
+8. Update `.bluent/PROJECT.md`, Issue #368, and PR #369 with exact evidence.
+9. Mark PR #369 ready for review only after the Sprint 2 definition of done is satisfied.
+10. Do not merge the PR without maintainer review.
+
+## Constraints
+
+- Do not introduce new public Bluent APIs or product components.
+- Reuse existing Bluent components and established demo infrastructure.
+- Do not introduce a new design system or unrelated CSS framework.
+- Preserve light/dark mode and LTR/RTL behavior.
+- Preserve existing package boundaries and public API conventions.
+- Do not claim runtime, responsive, render-mode, or deployment validation unless it actually ran.
+- Keep commits focused and reviewable.
+- Record any source/documentation mismatch instead of guessing.
+- Keep Issue #366 render-mode validation separate unless a Sprint 2 change directly depends on it.
+
+## Completion Protocol
+
+Sprint 2 is complete only when:
+
+- the landing page clearly positions Bluent;
+- navigation is structured and usable on desktop and mobile;
+- at least three enterprise scenarios run successfully;
+- themes and direction modes are visually validated;
+- screenshots accurately represent the current product;
+- required CI and deployment checks pass;
+- `.bluent/PROJECT.md`, Issue #368, and PR #369 contain the final evidence;
+- PR #369 is ready for maintainer review against `Dev`.

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -7,9 +7,9 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 ## Current Phase
 
 **Phase:** Project Relaunch  
-**Current Sprint:** Sprint 1 — Documentation Foundation  
-**Status:** Complete — validated in [PR #367](https://github.com/vrassouli/Bluent/pull/367)  
-**Working Branch:** `docs/sprint-1-foundation`
+**Current Sprint:** Sprint 2 — Demo and Visual Presentation  
+**Status:** In Progress  
+**Working Branch:** `demo/sprint-2-visual-presentation`
 
 ## Working Agreement
 
@@ -51,35 +51,21 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 - [x] Add GitHub issue templates.
 - [x] Add a pull request template.
 - [x] Review all relaunch changes for consistency.
-- [x] Open the project relaunch pull request into `Dev` ([PR #364](https://github.com/vrassouli/Bluent/pull/364)).
+- [x] Open and merge the project relaunch pull request into `Dev` ([PR #364](https://github.com/vrassouli/Bluent/pull/364)).
 
 ### Completion Summary
 
 - [PR #364](https://github.com/vrassouli/Bluent/pull/364) was merged into `Dev` on 2026-07-25.
-- The branch was based directly on `Dev` and was not behind it at final review.
 - README setup instructions were verified against service registration, layout containers, and packaged stylesheet paths.
-- NuGet metadata now uses the Apache-2.0 license expression, valid project/repository URLs, focused descriptions and tags, and a packaged README.
+- NuGet metadata uses the Apache-2.0 license expression, valid project/repository URLs, focused descriptions and tags, and a packaged README.
 - Repository documents and templates link to canonical project policies.
 - No product features were added.
-- The existing GitHub Pages workflow still targets `master`, .NET 9, and Actions v3. Updating CI is deferred to a dedicated quality task because it is outside Sprint 0's documentation and repository-professionalization scope.
-- A full solution build/test/package validation was not recorded before merge; this remains a quality follow-up and must be completed before the next package release.
-
-### Definition of Done
-
-Sprint 0 is complete when:
-
-- [x] The repository has a clear license and project identity.
-- [x] README instructions have been verified against the implementation.
-- [x] Contribution and community guidelines exist.
-- [x] Release and versioning expectations are documented.
-- [x] NuGet repository metadata is valid.
-- [x] Issue and pull request templates are available.
-- [x] All changes are available in one pull request targeting `Dev` ([PR #364](https://github.com/vrassouli/Bluent/pull/364)).
 
 ## Sprint 1 — Documentation Foundation
 
 **Tracking:** [Issue #365](https://github.com/vrassouli/Bluent/issues/365)  
-**Branch:** `docs/sprint-1-foundation`
+**Branch:** `docs/sprint-1-foundation`  
+**Pull Request:** [PR #367](https://github.com/vrassouli/Bluent/pull/367) — merged
 
 ### Completed
 
@@ -97,37 +83,44 @@ Sprint 0 is complete when:
 - [x] Define 15 representative AI benchmark prompts.
 - [x] Execute and publish the initial AI-readiness baseline.
 
-### Sprint 1 Completion Summary
+### Completion Summary
 
 - Canonical documentation architecture, Getting Started, package boundaries, hosting guidance, component standards, inventory, cross-cutting guidance, migration guidance, agent instructions, and `llms.txt` are published.
 - A compiled onboarding example covers common inputs, actions, feedback, and dialog usage.
-- The initial repository-context Codex baseline scored 99/150; generated consumer samples received no Build points because they were not compiled independently.
+- The initial repository-context Codex baseline scored 99/150.
 - GitHub Actions restored and built the full .NET 10 solution in Release configuration.
 - All 17 existing tests passed.
 - All five NuGet packages packed successfully and were uploaded as workflow artifacts.
 - Local Markdown links passed validation.
 - Build completed with 10 pre-existing compiler warnings and no errors.
-- Multi-model/context-free benchmarking and additional render-mode validation remain follow-up work, not hidden completion claims.
-
-### Definition of Done
-
-- [x] Installation and setup have one canonical, source-verified guide.
-- [x] Package boundaries and hosting/render-mode evidence are explicit.
-- [x] Component documentation has a repeatable template and coverage inventory.
-- [x] Coding agents have repository instructions and a maintained documentation index.
-- [x] A dated AI-readiness baseline records accuracy, gaps, and build limitations.
-- [x] The solution builds, tests pass, packages pack, and local documentation links resolve.
 
 ## Sprint 2 — Demo and Visual Presentation
 
-### Planned
+**Branch:** `demo/sprint-2-visual-presentation`
 
-- [ ] Redesign the demo landing page.
-- [ ] Build a structured component showcase.
-- [ ] Capture professional screenshots.
-- [ ] Produce short usage GIFs or videos.
+### Active Order
+
+- [ ] Audit the current demo application, page structure, navigation, and component coverage.
+- [ ] Define the demo information architecture and visual direction.
+- [ ] Redesign the demo landing page around Bluent's enterprise strengths.
+- [ ] Build a structured and searchable component showcase.
 - [ ] Improve mobile and desktop demo navigation.
-- [ ] Make the project's strongest differentiators immediately visible.
+- [ ] Add clear package, hosting, RTL, localization, and theming demonstrations.
+- [ ] Make Bluent's strongest differentiators immediately visible.
+- [ ] Capture professional screenshots for the README and project pages.
+- [ ] Produce short usage GIFs or videos where they add clear value.
+- [ ] Validate demo build, links, responsive behavior, and static deployment.
+- [ ] Open one focused Sprint 2 pull request into `Dev`.
+
+### Definition of Done
+
+- The landing page explains what Bluent is and why an application team would choose it.
+- Important component families are easy to find from desktop and mobile navigation.
+- The showcase demonstrates real business-application scenarios, not only isolated controls.
+- Theme, dark/light mode, RTL, localization, dialogs, feedback, charts, and diagrams are visibly represented where supported.
+- README-quality screenshots are committed and accurately represent the current product.
+- The demo builds successfully and its deployment workflow is validated.
+- Sprint 2 is delivered in a reviewed pull request targeting `Dev`.
 
 ## Sprint 3 — Release and Community Readiness
 
@@ -140,14 +133,21 @@ Sprint 0 is complete when:
 - [ ] Review automated builds and tests.
 - [ ] Add accessibility and quality checks where practical.
 
+## Parallel Quality Follow-ups
+
+These tasks are important but should not silently expand the Sprint 2 visual scope.
+
+1. [Issue #366](https://github.com/vrassouli/Bluent/issues/366) — validate Interactive Server, Interactive WebAssembly, and Interactive Auto render modes.
+2. Modernize and validate `.github/workflows/static.yml` before relying on the demo deployment.
+3. Resolve or triage the 10 existing compiler warnings before the next stable release.
+4. Expand the AI benchmark to context-free and multiple-model runs.
+5. Continue [Issue #363](https://github.com/vrassouli/Bluent/issues/363) by adding verified references/examples for public components and compiling representative AI-generated consumer samples.
+
 ## Backlog
 
-These items are intentionally deferred until the relaunch foundation is complete.
-
-- Update and validate the GitHub Pages workflow.
-- Documentation website or GitHub Pages redesign.
+- Documentation website or GitHub Pages redesign beyond the Sprint 2 demo scope.
 - Brand guide and visual identity refinement.
-- Public component coverage matrix.
+- Public component coverage matrix enhancements.
 - Automated API documentation.
 - Community outreach and launch announcement.
 - Showcase of applications built with Bluent.
@@ -189,19 +189,12 @@ These items are intentionally deferred until the relaunch foundation is complete
 **Tracking:** [Issue #363](https://github.com/vrassouli/Bluent/issues/363)  
 **Status:** Accepted
 
-## Known Follow-up Work
-
-- Modernize and validate `.github/workflows/static.yml`.
-- Resolve or triage the 10 existing compiler warnings before the next stable release.
-- Expand the AI benchmark to context-free and multiple-model runs.
-- Validate additional Blazor Web App render modes through [Issue #366](https://github.com/vrassouli/Bluent/issues/366).
-
 ## Session Resume Procedure
 
 When resuming work on Bluent:
 
-1. Read this file.
-2. Check the current branch and open pull requests.
+1. Read this file from `Dev` and from the active working branch.
+2. Check open pull requests and issues before assuming sprint status.
 3. Continue with the first unchecked task in the current sprint.
 4. Update this file after completing or changing a task.
-5. Do not start a later sprint while the current sprint's definition of done remains unmet.
+5. Keep parallel quality work explicitly separated from the active sprint scope.

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -9,7 +9,18 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 **Phase:** Project Relaunch  
 **Current Sprint:** Sprint 2 — Demo and Visual Presentation  
 **Status:** In Progress  
-**Working Branch:** `demo/sprint-2-visual-presentation`
+**Working Branch:** `demo/sprint-2-visual-presentation`  
+**Pull Request:** [#369](https://github.com/vrassouli/Bluent/pull/369) — draft  
+**Tracking Issue:** [#368](https://github.com/vrassouli/Bluent/issues/368)
+
+## Operational Files
+
+- `.bluent/HANDOFF.md` — immediate continuation instructions for Codex and other coding agents.
+- `.bluent/sprints/sprint-02.md` — detailed Sprint 2 execution plan and acceptance criteria.
+- `.bluent/QUALITY.md` — validation evidence and completion policy.
+- `.bluent/BACKLOG.md` — current, next, later, and deferred project work.
+- `docs/demo/sprint-2-audit.md` — source audit of the existing demo.
+- `src/Bluent.UI.Demo.Pages/AGENTS.md` — scoped instructions for demo work.
 
 ## Working Agreement
 
@@ -17,8 +28,9 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 - Prioritize documentation, presentation, reliability, adoption, and AI readiness.
 - Preserve API consistency across packages and components.
 - Avoid breaking changes unless they are necessary, documented, and reviewed.
-- Every completed project task must update this file.
-- Use this file as the first reference when resuming work.
+- Do not claim validation without recorded evidence defined in `.bluent/QUALITY.md`.
+- Every completed project task must update this file and the relevant tracking issue.
+- Use this file and `.bluent/HANDOFF.md` as the first references when resuming work.
 - Complete existing sprint work before starting a new sprint.
 
 ## Product Positioning
@@ -96,27 +108,36 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 
 ## Sprint 2 — Demo and Visual Presentation
 
-**Branch:** `demo/sprint-2-visual-presentation`
+Detailed plan: `.bluent/sprints/sprint-02.md`
 
-### Active Order
+### Completed on Active Branch
 
-- [ ] Audit the current demo application, page structure, navigation, and component coverage.
-- [ ] Define the demo information architecture and visual direction.
-- [ ] Redesign the demo landing page around Bluent's enterprise strengths.
-- [ ] Build a structured and searchable component showcase.
-- [ ] Improve mobile and desktop demo navigation.
-- [ ] Add clear package, hosting, RTL, localization, and theming demonstrations.
-- [ ] Make Bluent's strongest differentiators immediately visible.
-- [ ] Capture professional screenshots for the README and project pages.
-- [ ] Produce short usage GIFs or videos where they add clear value.
-- [ ] Validate demo build, links, responsive behavior, and static deployment.
-- [ ] Open one focused Sprint 2 pull request into `Dev`.
+- [x] Audit the current demo application, page structure, navigation, and component coverage.
+- [x] Define the initial demo information architecture and visual direction.
+- [x] Replace the default landing page with product positioning and calls to action.
+- [x] Add an in-demo Getting Started destination.
+- [x] Group navigation by purpose and support compact/expanded behavior.
+- [x] Highlight themes, dark mode, RTL, Charts, and Diagrams.
+- [x] Run initial restore, Release build, tests, package creation, and Markdown-link validation in GitHub Actions.
+- [x] Add Codex handoff, backlog, quality policy, sprint plan, and scoped demo-agent instructions.
+
+### Remaining
+
+- [ ] Add at least three runnable enterprise scenario pages.
+- [ ] Apply a repeatable component showcase structure to high-value pages.
+- [ ] Validate desktop and mobile navigation in a running browser.
+- [ ] Validate light/dark and LTR/RTL combinations.
+- [ ] Capture professional screenshots from the validated application.
+- [ ] Modernize and validate static deployment where required.
+- [ ] Record final validation evidence and remaining risks.
+- [ ] Mark PR #369 ready for review.
+- [ ] Merge the reviewed Sprint 2 pull request into `Dev`.
 
 ### Definition of Done
 
 - The landing page explains what Bluent is and why an application team would choose it.
 - Important component families are easy to find from desktop and mobile navigation.
-- The showcase demonstrates real business-application scenarios, not only isolated controls.
+- The showcase demonstrates at least three real business-application scenarios.
 - Theme, dark/light mode, RTL, localization, dialogs, feedback, charts, and diagrams are visibly represented where supported.
 - README-quality screenshots are committed and accurately represent the current product.
 - The demo builds successfully and its deployment workflow is validated.
@@ -143,18 +164,6 @@ These tasks are important but should not silently expand the Sprint 2 visual sco
 4. Expand the AI benchmark to context-free and multiple-model runs.
 5. Continue [Issue #363](https://github.com/vrassouli/Bluent/issues/363) by adding verified references/examples for public components and compiling representative AI-generated consumer samples.
 
-## Backlog
-
-- Documentation website or GitHub Pages redesign beyond the Sprint 2 demo scope.
-- Brand guide and visual identity refinement.
-- Public component coverage matrix enhancements.
-- Automated API documentation.
-- Community outreach and launch announcement.
-- Showcase of applications built with Bluent.
-- Package naming and boundary review.
-- Release cadence review.
-- Evaluate a Bluent MCP or generated AI context bundle only after canonical static documentation exists.
-
 ## Accepted Decisions
 
 ### 2026-07-25 — Pause new features
@@ -177,8 +186,8 @@ These tasks are important but should not silently expand the Sprint 2 visual sco
 
 ### 2026-07-25 — Repository-based project tracking
 
-**Decision:** Track relaunch progress in `.bluent/PROJECT.md`.  
-**Reason:** The file is version-controlled, readable by contributors, and can be used to resume future work without reconstructing project state from chat history.  
+**Decision:** Track relaunch progress in `.bluent/PROJECT.md`, maintain immediate work in `.bluent/HANDOFF.md`, and keep detailed sprint execution under `.bluent/sprints/`.  
+**Reason:** Version-controlled project state enables reliable continuation by maintainers and coding agents without reconstructing context from chat history.  
 **Status:** Accepted
 
 ### 2026-07-25 — AI readiness and discoverability
@@ -193,8 +202,10 @@ These tasks are important but should not silently expand the Sprint 2 visual sco
 
 When resuming work on Bluent:
 
-1. Read this file from `Dev` and from the active working branch.
-2. Check open pull requests and issues before assuming sprint status.
-3. Continue with the first unchecked task in the current sprint.
-4. Update this file after completing or changing a task.
-5. Keep parallel quality work explicitly separated from the active sprint scope.
+1. Read root `AGENTS.md`.
+2. Read `.bluent/HANDOFF.md`, this file, and the active sprint plan.
+3. Check open pull requests and issues before assuming sprint status.
+4. Continue in the documented execution order.
+5. Apply `.bluent/QUALITY.md` before claiming completion.
+6. Update this file, the tracking issue, and the pull request as work progresses.
+7. Keep parallel quality work explicitly separated from the active sprint scope.

--- a/.bluent/QUALITY.md
+++ b/.bluent/QUALITY.md
@@ -1,0 +1,100 @@
+# Bluent Quality and Validation Policy
+
+This file defines the evidence required before an agent or contributor may claim that Bluent work is complete or validated.
+
+## Evidence Vocabulary
+
+These claims are distinct:
+
+- **Source verified** — confirmed by reading the current implementation.
+- **Build verified** — the relevant project or solution compiled successfully.
+- **Test verified** — the relevant automated tests ran and passed.
+- **Pack verified** — NuGet packages were created and their expected contents/metadata were checked.
+- **Runtime verified** — the behavior was exercised in a running application.
+- **Visual verified** — the rendered result was reviewed at the stated viewport, theme, and direction.
+- **Deployment verified** — the deployment workflow ran successfully and the deployed application was checked.
+
+Never substitute one kind of evidence for another.
+
+## Required for Every Pull Request
+
+- State the user-visible outcome.
+- Identify affected projects, packages, components, and documentation.
+- Run the narrowest relevant checks plus the repository-required checks.
+- Record exact commands and results.
+- Disclose skipped, unavailable, or failed validation.
+- Document public behavior changes and migration impact.
+- Update canonical documentation and project tracking when applicable.
+
+## Baseline Repository Validation
+
+Run from the repository root:
+
+```bash
+dotnet tool restore
+dotnet restore Bluent.sln
+dotnet build Bluent.sln --configuration Release
+dotnet test Bluent.sln --configuration Release --no-build
+```
+
+For package-affecting work, also run Release packing for affected packable projects and inspect:
+
+- package ID and version metadata;
+- dependencies;
+- README and license inclusion;
+- static web assets;
+- symbols/source configuration where applicable.
+
+## Documentation Validation
+
+- Resolve local Markdown links.
+- Verify commands, namespaces, package IDs, asset paths, and examples against current source.
+- Compile or run examples when the document claims they are runnable.
+- Update `llms.txt` when canonical documentation is added, moved, or removed.
+- Update component inventory when public component coverage changes.
+
+## Demo and Visual Work
+
+Required before Sprint 2 completion:
+
+- Run the Blazor WebAssembly demo.
+- Review the Home, Getting Started, navigation, selected component pages, and scenario pages in a browser.
+- Test representative desktop and mobile viewport widths.
+- Test light and dark themes.
+- Test LTR and RTL direction.
+- Confirm interactive controls, navigation, dialogs, overlays, and scenario workflows behave as intended.
+- Check the browser console for relevant errors.
+- Confirm layout does not introduce obvious clipping, overflow, unreadable content, or unreachable navigation.
+- Capture screenshots only from the validated running application.
+- Record environment details: .NET SDK, browser, OS, commit SHA, and relevant host.
+
+## Deployment Validation
+
+- Review the workflow target branch, SDK version, and action versions.
+- Run the static deployment workflow successfully.
+- Confirm generated base paths and static assets resolve correctly.
+- Open the deployed site and test primary routes directly and through navigation.
+- Record the workflow run and deployed URL in the PR.
+
+## Public API Changes
+
+For any public component or API change:
+
+- compare sibling APIs and inherited parameters;
+- preserve binding and event naming conventions;
+- review accessibility, keyboard, localization, RTL, and JavaScript lifecycle effects;
+- add or update runnable examples;
+- add tests when behavior can be covered automatically;
+- add an `Unreleased` changelog entry;
+- add migration guidance for breaking changes.
+
+## Completion Rules
+
+An item may be checked off only when its acceptance criteria and required evidence are recorded.
+
+A sprint may be marked complete only when:
+
+- all Definition of Done items are satisfied;
+- required validation has run;
+- known limitations and remaining risks are explicit;
+- project tracking and public issue/PR status agree.

--- a/.bluent/sprints/sprint-02.md
+++ b/.bluent/sprints/sprint-02.md
@@ -1,0 +1,130 @@
+# Sprint 2 — Demo and Visual Presentation
+
+## Goal
+
+Turn the Bluent demo into a credible public product experience for teams evaluating an enterprise Blazor UI toolkit.
+
+## Tracking
+
+- Branch: `demo/sprint-2-visual-presentation`
+- Pull request: [#369](https://github.com/vrassouli/Bluent/pull/369)
+- Issue: [#368](https://github.com/vrassouli/Bluent/issues/368)
+- Audit: `docs/demo/sprint-2-audit.md`
+
+## Non-Goals
+
+- Adding new public Bluent components.
+- Redesigning package boundaries or public APIs.
+- Completing the separate render-mode validation tracked by Issue #366.
+- Building a full documentation platform beyond the current demo scope.
+- Introducing unrelated design frameworks or broad infrastructure rewrites.
+
+## Workstreams
+
+### 1. Landing and Positioning
+
+- [x] Replace the default Blazor starter home page.
+- [x] Explain Bluent's enterprise positioning.
+- [x] Add clear calls to action.
+- [x] Highlight themes, dark mode, RTL, Charts, and Diagrams.
+- [ ] Complete browser-based review of the landing page.
+
+### 2. Navigation and Discovery
+
+- [x] Add Home and Getting Started destinations.
+- [x] Group component links by purpose.
+- [x] Promote Charts and Diagrams.
+- [x] Support compact and expanded navigation.
+- [ ] Validate desktop behavior.
+- [ ] Validate mobile behavior.
+- [ ] Validate navigation in LTR and RTL.
+
+### 3. Component Showcase Standard
+
+Define a repeatable structure for high-value component pages:
+
+1. purpose and business use;
+2. package and namespace;
+3. interactive example;
+4. source snippet or source reference;
+5. important parameters/events;
+6. theme, RTL, accessibility, and hosting notes;
+7. limitations and validation evidence.
+
+Apply it first to:
+
+- [ ] Buttons/actions.
+- [ ] Fields/forms.
+- [ ] Data Grid and Data Pager.
+- [ ] Dialogs, Toasts, and Message Bars.
+- [ ] Charts.
+- [ ] Diagrams.
+
+### 4. Enterprise Scenarios
+
+Implement at least three runnable scenarios using existing public components:
+
+- [ ] Customer profile form — common fields, validation affordances, primary/secondary actions.
+- [ ] Operations dashboard — cards, statuses, table/grid, feedback, and charts where supported.
+- [ ] Search and filter workspace — filters, results, paging, empty/loading state.
+- [ ] Confirmation and notification flow — dialog, message bar, toast, and action handling.
+- [ ] RTL business form — demonstrate direction, alignment, and localized business UI.
+
+Preferred minimum set for completion:
+
+1. Customer profile form.
+2. Operations dashboard.
+3. Confirmation and notification flow.
+
+### 5. Visual and Runtime Validation
+
+- [ ] Run the WebAssembly demo.
+- [ ] Review Home and Getting Started in a browser.
+- [ ] Review selected showcase pages and all completed scenario pages.
+- [ ] Validate representative desktop widths.
+- [ ] Validate representative mobile widths.
+- [ ] Validate light theme.
+- [ ] Validate dark theme.
+- [ ] Validate LTR.
+- [ ] Validate RTL.
+- [ ] Check browser console and navigation errors.
+- [ ] Record environment and commit SHA.
+
+### 6. Assets and Deployment
+
+- [ ] Capture README-quality landing screenshot.
+- [ ] Capture component showcase screenshot.
+- [ ] Capture enterprise scenario screenshot.
+- [ ] Capture RTL or theme demonstration screenshot.
+- [ ] Modernize static deployment workflow where required for this demo.
+- [ ] Run and validate the static deployment workflow.
+- [ ] Check deployed routes and assets.
+
+### 7. Finalization
+
+- [ ] Run Release restore/build/test.
+- [ ] Pack all five packages where the workflow requires it.
+- [ ] Validate local Markdown links.
+- [ ] Update `.bluent/PROJECT.md`.
+- [ ] Update Issue #368 with evidence.
+- [ ] Update PR #369 with exact validation and remaining risks.
+- [ ] Mark PR #369 ready for review.
+
+## Acceptance Criteria
+
+- The demo immediately explains what Bluent is and who it serves.
+- Users can find major component families without scanning one flat list.
+- At least three enterprise scenarios are runnable.
+- Existing Bluent strengths are visibly demonstrated rather than only described.
+- Desktop/mobile and theme/direction combinations have recorded runtime evidence.
+- Screenshots are current and truthful.
+- Build, tests, package checks, links, and deployment checks pass or any limitation is explicitly recorded.
+- The sprint is delivered through one reviewed PR into `Dev`.
+
+## Risks
+
+- Visual changes can hide RTL, overflow, focus, or responsive defects.
+- Demo-only CSS may diverge from actual component behavior.
+- Existing components may not cover a desired scenario without exposing gaps; record gaps rather than adding unapproved public APIs.
+- Static hosting base paths may differ from local hosting.
+- Browser and screenshot validation cannot be inferred from CI build success.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,18 @@ Bluent is a Blazor-native toolkit for modern business applications. The current 
 
 Read these sources before making changes:
 
-1. `.bluent/PROJECT.md`
-2. `VISION.md`
-3. `ROADMAP.md`
-4. `CONTRIBUTING.md`
-5. `docs/README.md`
-6. the documentation page for the affected package or component
+1. `.bluent/HANDOFF.md`
+2. `.bluent/PROJECT.md`
+3. the active sprint plan under `.bluent/sprints/`
+4. `.bluent/QUALITY.md`
+5. `VISION.md`
+6. `ROADMAP.md`
+7. `CONTRIBUTING.md`
+8. `docs/README.md`
+9. the nearest scoped `AGENTS.md`
+10. the documentation page for the affected package or component
+
+Use `.bluent/BACKLOG.md` for unscheduled and future work. Do not silently pull backlog items into the active sprint.
 
 ## Guardrails
 
@@ -23,8 +29,9 @@ Read these sources before making changes:
 - Do not invent support claims, components, parameters, events, namespaces, render modes, or static assets.
 - Treat current source and verified examples as evidence; report documentation/source mismatches.
 - Do not describe a demo page as validation unless its behavior was actually built or run.
+- Apply the evidence definitions and completion rules in `.bluent/QUALITY.md`.
 - Keep changes focused and reviewable.
-- Update `.bluent/PROJECT.md` and the tracking issue when completing project work.
+- Update `.bluent/PROJECT.md`, the active tracking issue, and the pull request when completing project work.
 
 ## Repository map
 
@@ -35,8 +42,9 @@ Read these sources before making changes:
 - `src/Bluent.UI.Utilities` — higher-level application utilities; NuGet package `Bluent.UI.Utilities`
 - `src/Bluent.UI.Demo` — Blazor WebAssembly demo host
 - `src/Bluent.UI.Demo.SSR` — Blazor Web App/static SSR host
-- `src/Bluent.UI.Demo.Pages` — shared demo pages
+- `src/Bluent.UI.Demo.Pages` — shared demo pages; follow its scoped `AGENTS.md`
 - `docs` — canonical product documentation
+- `.bluent` — project state, handoff, backlog, quality policy, and sprint execution plans
 
 Package IDs and project directory names are not always identical. Verify the project file before writing installation instructions.
 
@@ -79,7 +87,7 @@ dotnet test Bluent.sln --configuration Release --no-build
 
 For package work, also pack the affected projects in Release configuration and inspect the resulting package metadata, dependencies, README, license, and static assets.
 
-Do not claim that validation passed unless the command actually ran successfully. Record commands, configuration, relevant environment, and failures.
+Do not claim that validation passed unless the command actually ran successfully. Record commands, configuration, relevant environment, and failures. Follow `.bluent/QUALITY.md` for runtime, visual, documentation, package, and deployment evidence.
 
 ## Documentation rules
 
@@ -124,7 +132,7 @@ A pull request should state:
 - affected packages/components
 - source and documentation changes
 - build/test/pack commands actually run
-- render modes tested
+- runtime, visual, deployment, and render modes actually tested
 - breaking changes and migration steps
 - remaining risks or unverified behavior
 

--- a/docs/demo/sprint-2-audit.md
+++ b/docs/demo/sprint-2-audit.md
@@ -1,0 +1,170 @@
+# Sprint 2 Demo Audit
+
+This document records the current state of the Bluent demo application and defines the implementation order for Sprint 2.
+
+## Executive Summary
+
+The demo contains a broad component showcase, but its presentation layer is not yet suitable as the public face of Bluent.
+
+The main problems are:
+
+- The landing page is still the default Blazor starter page.
+- Navigation is a flat component list with no information hierarchy.
+- The public experience does not explain Bluent's product positioning or enterprise value.
+- Component pages exist in large numbers, but discovery is weak.
+- Theme, dark mode, and RTL controls are implemented and should be elevated as visible differentiators.
+- Charts and Diagrams already have dedicated demo pages and should be presented as first-class packages.
+
+## Current Application Structure
+
+### Layout
+
+The demo uses:
+
+- `MainLayout.razor` for the application shell.
+- `Header.razor` for global controls and branding.
+- `Side.razor` for the primary component navigation.
+- `<Containers />` at layout level for global overlay services.
+
+This is a sound technical base and should be retained.
+
+### Header Capabilities
+
+The current header already provides:
+
+- Side navigation expansion and collapse.
+- Bluent home navigation.
+- Theme color selection.
+- Light and dark mode switching.
+- LTR and RTL direction switching.
+- Local persistence through local storage.
+
+These capabilities are strong differentiators and should remain visible in the redesigned demo.
+
+### Navigation
+
+The active side navigation is a single vertical `TabList` containing component links.
+
+Observed issues:
+
+- No Home entry in the active navigation.
+- No Getting Started or conceptual documentation entry.
+- No grouping by component purpose.
+- Charts and Diagrams are mixed into the base component list.
+- No enterprise-scenario or workflow examples.
+- No search or quick filtering.
+- The `Expanded` parameter is not currently used by `Side.razor`.
+- A previous hierarchical `NavList` implementation exists only as commented code.
+
+### Landing Page
+
+The home page currently renders:
+
+```text
+Hello, world!
+Welcome to your new app.
+```
+
+This is the highest-priority presentation defect in the project.
+
+### Component Coverage
+
+The demo has broad page coverage, including at least:
+
+- Inputs and forms: fields, checkboxes, radios, sliders, dropdowns, file selection.
+- Actions and feedback: buttons, dialogs, drawers, message bars, popovers, toasts, tooltips.
+- Navigation and structure: breadcrumbs, menus, tabs, trees, wizards, lists.
+- Data and layout: data grids, pagers, cards, stacks, split panels, dock panels.
+- Rich capabilities: charts, diagrams, drawing canvas, audio capture.
+- Visual system: icons, labels, tags, badges, skeletons, progress bars.
+
+The issue is therefore not lack of demo content; it is discoverability, hierarchy, polish, and positioning.
+
+## Sprint 2 Target Information Architecture
+
+The public demo should use this top-level structure:
+
+1. Home
+2. Getting Started
+3. Components
+   - Actions
+   - Inputs and Forms
+   - Navigation
+   - Feedback and Overlays
+   - Data Display
+   - Layout
+   - Status and Visuals
+4. Charts
+5. Diagrams
+6. Enterprise Scenarios
+
+The exact component-to-category mapping should be maintained in code rather than duplicated manually across multiple files.
+
+## Implementation Order
+
+### Phase 1 — Public Landing Experience
+
+- Replace the starter home page.
+- Add a clear value proposition.
+- Add primary calls to action for Getting Started and Components.
+- Highlight enterprise application use cases.
+- Highlight dark mode, theme colors, RTL, charts, and diagrams.
+- Add a concise package overview.
+
+### Phase 2 — Navigation Architecture
+
+- Replace the flat list with grouped navigation.
+- Add Home and Getting Started entries.
+- Separate Charts and Diagrams from general components.
+- Preserve mobile collapse behavior.
+- Use the `Expanded` state to support compact and full navigation modes.
+- Add accessible group labels and predictable active states.
+
+### Phase 3 — Component Showcase Consistency
+
+- Define one visual page structure for component demos.
+- Add overview, examples, package name, and source links consistently.
+- Prioritize the most important enterprise components first.
+- Mark incomplete or experimental examples honestly.
+
+### Phase 4 — Enterprise Scenarios
+
+Add runnable pages that combine multiple components, beginning with:
+
+- Customer profile form.
+- Operations dashboard.
+- Search and filter workspace.
+- Confirmation and notification flow.
+- RTL business form.
+
+### Phase 5 — Responsive and Visual Validation
+
+- Validate desktop navigation.
+- Validate mobile navigation.
+- Validate dark and light modes.
+- Validate LTR and RTL layouts.
+- Validate theme colors.
+- Capture final screenshots and short demonstrations.
+
+## Technical Follow-ups Outside Core Sprint 2
+
+These remain separate quality tasks unless they block deployment:
+
+- Modernize the GitHub Pages workflow.
+- Validate Interactive Server, Interactive WebAssembly, and Interactive Auto through Issue #366.
+- Resolve or formally triage existing compiler warnings.
+- Expand AI-readiness benchmarking.
+
+## Definition of Done
+
+Sprint 2 is complete when:
+
+- The default starter landing page is gone.
+- The demo clearly explains Bluent and its intended use.
+- Navigation is grouped and works on desktop and mobile.
+- Charts and Diagrams are first-class destinations.
+- At least three enterprise scenarios are runnable.
+- Dark/light, theme color, LTR/RTL, and responsive behavior are validated.
+- Professional screenshots are committed or linked from the README.
+- The solution builds and existing tests pass.
+- One reviewed pull request targets `Dev`.

--- a/src/Bluent.UI.Demo.Pages/AGENTS.md
+++ b/src/Bluent.UI.Demo.Pages/AGENTS.md
@@ -1,0 +1,65 @@
+# Demo Pages Agent Instructions
+
+These instructions apply to work under `src/Bluent.UI.Demo.Pages`.
+
+Read the repository-root `AGENTS.md`, `.bluent/HANDOFF.md`, `.bluent/QUALITY.md`, and the active sprint plan before making changes.
+
+## Purpose
+
+The demo is a public product experience and a source of verified usage examples. It must help developers understand Bluent, evaluate its capabilities, and learn correct usage patterns.
+
+## Guardrails
+
+- Use existing public Bluent components and APIs.
+- Do not add or change public library APIs merely to simplify a demo page without explicit maintainer approval.
+- Do not introduce a second design system or unrelated CSS framework.
+- Prefer scoped demo styles and existing design tokens/utilities.
+- Preserve light and dark themes.
+- Preserve LTR and RTL direction.
+- Keep desktop and mobile navigation usable.
+- Do not copy canonical setup instructions when a link or concise verified summary is sufficient.
+- Do not claim compatibility or runtime validation that was not exercised.
+- Keep examples realistic but free of secrets, external service dependencies, and unnecessary complexity.
+
+## Page Expectations
+
+For product and scenario pages:
+
+- Provide a meaningful page title and concise purpose.
+- Demonstrate business-application usage rather than decorative controls alone.
+- Use accessible labels and meaningful action text.
+- Include loading, empty, success, warning, or error states when relevant.
+- Ensure examples remain understandable in both LTR and RTL.
+- Avoid fixed dimensions that break common mobile widths unless the example specifically demonstrates fixed sizing.
+
+For component showcase pages, prefer this structure:
+
+1. Purpose and common use cases.
+2. Interactive example.
+3. Correct package and namespace reference.
+4. Important parameters, events, and binding patterns.
+5. Theme, RTL, accessibility, hosting, or JavaScript notes.
+6. Limitations and verification evidence.
+
+## Navigation
+
+- Keep Home and Getting Started easy to reach.
+- Group components by user intent or application purpose.
+- Keep Charts and Diagrams visible as first-class capabilities.
+- Compact navigation must remain understandable through icons, labels, tooltips, or an equivalent accessible mechanism.
+- New pages must be linked from the appropriate navigation group unless intentionally hidden and documented.
+
+## Validation
+
+Before claiming demo work complete:
+
+- run the repository build and tests;
+- run the demo in a browser;
+- test representative desktop and mobile widths;
+- test light and dark themes;
+- test LTR and RTL;
+- check navigation, interaction, overlays, and browser console errors;
+- record the tested environment and commit SHA;
+- capture screenshots only after runtime validation.
+
+Update `.bluent/PROJECT.md`, the active sprint issue, and the pull request with exact evidence.

--- a/src/Bluent.UI.Demo.Pages/Layout/Side.razor
+++ b/src/Bluent.UI.Demo.Pages/Layout/Side.razor
@@ -1,80 +1,78 @@
-﻿@using Microsoft.AspNetCore.Components.Routing
-@* <NavList Compact="@(!Expanded)"> *@
-@*     <NavItem Text="Home" *@
-@*              Icon="icon-ic_fluent_home_20_regular" *@
-@*              ActiveIcon="icon-ic_fluent_home_20_filled" *@
-@*              Href="/" *@
-@*              Match="NavLinkMatch.All"> *@
-@*         <Options> *@
-@*             <Badge Text="2" Shape="BadgeShape.Circular" Color="BadgeColor.Brand" Size="BadgeSize.Small"></Badge> *@
-@*         </Options> *@
-@*     </NavItem> *@
-@*     <NavItem Text="Navigations" *@
-@*              Icon="icon-ic_fluent_arrow_collapse_all_20_regular" *@
-@*              ActiveIcon="icon-ic_fluent_arrow_collapse_all_20_filled" > *@
-@*         <NavItem Text="Accordions" *@
-@*                  Icon="icon-ic_fluent_arrow_collapse_all_20_regular" *@
-@*                  ActiveIcon="icon-ic_fluent_arrow_collapse_all_20_filled" *@
-@*                  Href="components/accordions"/> *@
-@*         <NavItem Text="Action Cards" *@
-@*                  Icon="icon-ic_fluent_arrow_collapse_all_20_regular" *@
-@*                  ActiveIcon="icon-ic_fluent_arrow_collapse_all_20_filled"  *@
-@*                  Href="components/action-cards"/> *@
-@*     </NavItem> *@
-@*     <NavItem Text="Utilities" *@
-@*              Icon="icon-ic_fluent_arrow_collapse_all_20_regular" *@
-@*              ActiveIcon="icon-ic_fluent_arrow_collapse_all_20_filled" > *@
-@*         <NavItem Text="Audio Capture"  *@
-@*                  Icon="icon-ic_fluent_mic_20_regular" *@
-@*                  ActiveIcon="icon-ic_fluent_mic_20_filled" *@
-@*                  Href="components/audio-captures" /> *@
-@*     </NavItem> *@
-@* </NavList> *@
+@using Microsoft.AspNetCore.Components.Routing
 
-<TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical" Class="h-100">
-    <Tab Text="Avatars" Icon="icon-ic_fluent_person_circle_20_regular" ActiveIcon="icon-ic_fluent_person_circle_20_filled" Href="components/avatars" Orientation="Orientation.Vertical" />
-    <Tab Text="Badges" Icon="icon-ic_fluent_badge_20_regular" ActiveIcon="icon-ic_fluent_badge_20_filled" Href="components/badges" Orientation="Orientation.Vertical" />
-    <Tab Text="Breadcrumbs" Icon="icon-ic_fluent_document_chevron_double_20_regular" ActiveIcon="icon-ic_fluent_document_chevron_double_20_filled" Href="components/breadcrumbs" Orientation="Orientation.Vertical" />
-    <Tab Text="Buttons" Icon="icon-ic_fluent_button_20_regular" ActiveIcon="icon-ic_fluent_button_20_filled" Href="components/buttons" Orientation="Orientation.Vertical" />
-    <Tab Text="Calendar" Icon="icon-ic_fluent_calendar_20_regular" ActiveIcon="icon-ic_fluent_calendar_20_filled" Href="components/calendars" Orientation="Orientation.Vertical" />
-    <Tab Text="Cards" Icon="icon-ic_fluent_card_ui_20_regular" ActiveIcon="icon-ic_fluent_card_ui_20_filled" Href="components/cards" Orientation="Orientation.Vertical" />
-    <Tab Text="Charts" Icon="icon-ic_fluent_chart_multiple_20_regular" ActiveIcon="icon-ic_fluent_chart_multiple_20_filled" Href="components/charts" Orientation="Orientation.Vertical" />
-    <Tab Text="Checkboxes" Icon="icon-ic_fluent_checkbox_checked_20_regular" ActiveIcon="icon-ic_fluent_checkbox_checked_20_filled" Href="components/checkboxes" Orientation="Orientation.Vertical" />
-    <Tab Text="Data Grids" Icon="icon-ic_fluent_grid_20_regular" ActiveIcon="icon-ic_fluent_grid_20_filled" Href="components/data-grids" Orientation="Orientation.Vertical" />
-    <Tab Text="Data Pagers" Icon="icon-ic_fluent_arrow_fit_20_regular" ActiveIcon="icon-ic_fluent_arrow_fit_20_filled" Href="components/data-pagers" Orientation="Orientation.Vertical" />
-    <Tab Text="Diagrams" Icon="icon-ic_fluent_diagram_20_regular" ActiveIcon="icon-ic_fluent_diagram_20_filled" Href="components/diagrams" Orientation="Orientation.Vertical" />
-    <Tab Text="Dialogs" Icon="icon-ic_fluent_window_20_regular" ActiveIcon="icon-ic_fluent_window_20_filled" Href="components/dialogs" Orientation="Orientation.Vertical" />
-    <Tab Text="Drawers" Icon="icon-ic_fluent_slide_arrow_right_20_regular" ActiveIcon="icon-ic_fluent_slide_arrow_right_20_filled" Href="components/drawers" Orientation="Orientation.Vertical" />
-    <Tab Text="Drawing" Icon="icon-ic_fluent_draw_image_20_regular" ActiveIcon="icon-ic_fluent_draw_image_20_filled" Href="components/drawing-canvases" Orientation="Orientation.Vertical" />
-    <Tab Text="Dropdowns" Icon="icon-ic_fluent_list_bar_tree_20_regular" ActiveIcon="icon-ic_fluent_list_bar_tree_20_filled" Href="components/dropdowns" Orientation="Orientation.Vertical" />
-    <Tab Text="Dock Panels" Icon="icon-ic_fluent_layout_column_two_split_left_20_regular" ActiveIcon="icon-ic_fluent_layout_column_two_split_left_20_filled" Href="components/dock-panels" Orientation="Orientation.Vertical" />
-    <Tab Text="Fields" Icon="icon-ic_fluent_text_field_20_regular" ActiveIcon="icon-ic_fluent_text_field_20_filled" Href="components/fields" Orientation="Orientation.Vertical" />
-    <Tab Text="File Selects" Icon="icon-ic_fluent_attach_20_regular" ActiveIcon="icon-ic_fluent_attach_20_filled" Href="components/file-selects" Orientation="Orientation.Vertical" />
-    <Tab Text="Icons" Icon="icon-ic_fluent_icons_20_regular" ActiveIcon="icon-ic_fluent_icons_20_filled" Href="components/icons" Orientation="Orientation.Vertical" />
-    <Tab Text="Labels" Icon="icon-ic_fluent_tag_circle_20_regular" ActiveIcon="icon-ic_fluent_tag_circle_20_filled" Href="components/labels" Orientation="Orientation.Vertical" />
-    <Tab Text="Links" Icon="icon-ic_fluent_link_20_regular" ActiveIcon="icon-ic_fluent_link_20_filled" Href="components/links" Orientation="Orientation.Vertical" />
-    <Tab Text="Lists" Icon="icon-ic_fluent_list_20_regular" ActiveIcon="icon-ic_fluent_list_20_filled" Href="components/lists" Orientation="Orientation.Vertical" />
-    <Tab Text="Menus" Icon="icon-ic_fluent_text_bullet_list_square_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_square_20_filled" Href="components/menus" Orientation="Orientation.Vertical" />
-    <Tab Text="Message Bars" Icon="icon-ic_fluent_info_20_regular" ActiveIcon="icon-ic_fluent_info_20_filled" Href="components/message-bars" Orientation="Orientation.Vertical" />
-    <Tab Text="Popovers" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/popovers" Orientation="Orientation.Vertical" />
-    <Tab Text="Progress Bars" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/progress-bars" Orientation="Orientation.Vertical" />
-    <Tab Text="Radio" Icon="icon-ic_fluent_radio_button_20_regular" ActiveIcon="icon-ic_fluent_radio_button_20_filled" Href="components/radios" Orientation="Orientation.Vertical" />
-    <Tab Text="Skeletons" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/skeletons" Orientation="Orientation.Vertical" />
-    <Tab Text="Slider" Icon="icon-ic_fluent_line_flow_diagonal_up_right_20_regular" ActiveIcon="icon-ic_fluent_line_flow_diagonal_up_right_20_filled" Href="components/sliders" Orientation="Orientation.Vertical" />
-    <Tab Text="Spinners" Icon="icon-ic_fluent_spinner_ios_20_regular" ActiveIcon="icon-ic_fluent_spinner_ios_20_filled" Href="components/spinners" Orientation="Orientation.Vertical" />
-    <Tab Text="Split Panels" Icon="icon-ic_fluent_split_hint_20_regular" ActiveIcon="icon-ic_fluent_split_hint_20_filled" Href="components/split-panels" Orientation="Orientation.Vertical" />
-    <Tab Text="Stacks" Icon="icon-ic_fluent_stack_vertical_20_regular" ActiveIcon="icon-ic_fluent_stack_vertical_20_filled" Href="components/stacks" Orientation="Orientation.Vertical" />
-    <Tab Text="Tab lists" Icon="icon-ic_fluent_tab_desktop_20_regular" ActiveIcon="icon-ic_fluent_tab_desktop_20_filled" Href="components/tablists" Orientation="Orientation.Vertical" />
-    <Tab Text="Tags" Icon="icon-ic_fluent_tag_20_regular" ActiveIcon="icon-ic_fluent_tag_20_filled" Href="components/tags" Orientation="Orientation.Vertical" />
-    <Tab Text="Toasts" Icon="icon-ic_fluent_alert_urgent_20_regular" ActiveIcon="icon-ic_fluent_alert_urgent_20_filled" Href="components/toasts" Orientation="Orientation.Vertical" />
-    <Tab Text="Toolbars" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/toolbars" Orientation="Orientation.Vertical" />
-    <Tab Text="Tooltips" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/tooltips" Orientation="Orientation.Vertical" />
-    <Tab Text="Trees" Icon="icon-ic_fluent_text_bullet_list_tree_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_tree_20_filled" Href="components/trees" Orientation="Orientation.Vertical" />
-    <Tab Text="Wizards" Icon="icon-ic_fluent_slide_text_sparkle_20_regular" ActiveIcon="icon-ic_fluent_slide_text_sparkle_20_filled" Href="components/wizards" Orientation="Orientation.Vertical" />
-</TabList>
+<nav class="demo-nav @(Expanded ? "expanded" : "compact")" aria-label="Demo navigation">
+    <div class="primary-links">
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+            <Tab Text="@Label("Home")" Icon="icon-ic_fluent_home_20_regular" ActiveIcon="icon-ic_fluent_home_20_filled" Href="/" Orientation="Orientation.Vertical" />
+            <Tab Text="@Label("Charts")" Icon="icon-ic_fluent_chart_multiple_20_regular" ActiveIcon="icon-ic_fluent_chart_multiple_20_filled" Href="components/charts" Orientation="Orientation.Vertical" />
+            <Tab Text="@Label("Diagrams")" Icon="icon-ic_fluent_diagram_20_regular" ActiveIcon="icon-ic_fluent_diagram_20_filled" Href="components/diagrams" Orientation="Orientation.Vertical" />
+        </TabList>
+    </div>
 
-@code{
+    <NavGroup Title="Actions">
+        <Tab Text="@Label("Buttons")" Icon="icon-ic_fluent_button_20_regular" ActiveIcon="icon-ic_fluent_button_20_filled" Href="components/buttons" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Links")" Icon="icon-ic_fluent_link_20_regular" ActiveIcon="icon-ic_fluent_link_20_filled" Href="components/links" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Toolbars")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/toolbars" Orientation="Orientation.Vertical" />
+    </NavGroup>
 
+    <NavGroup Title="Inputs and forms">
+        <Tab Text="@Label("Fields")" Icon="icon-ic_fluent_text_field_20_regular" ActiveIcon="icon-ic_fluent_text_field_20_filled" Href="components/fields" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Checkboxes")" Icon="icon-ic_fluent_checkbox_checked_20_regular" ActiveIcon="icon-ic_fluent_checkbox_checked_20_filled" Href="components/checkboxes" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Radio")" Icon="icon-ic_fluent_radio_button_20_regular" ActiveIcon="icon-ic_fluent_radio_button_20_filled" Href="components/radios" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Dropdowns")" Icon="icon-ic_fluent_list_bar_tree_20_regular" ActiveIcon="icon-ic_fluent_list_bar_tree_20_filled" Href="components/dropdowns" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Calendar")" Icon="icon-ic_fluent_calendar_20_regular" ActiveIcon="icon-ic_fluent_calendar_20_filled" Href="components/calendars" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Sliders")" Icon="icon-ic_fluent_line_flow_diagonal_up_right_20_regular" ActiveIcon="icon-ic_fluent_line_flow_diagonal_up_right_20_filled" Href="components/sliders" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("File selects")" Icon="icon-ic_fluent_attach_20_regular" ActiveIcon="icon-ic_fluent_attach_20_filled" Href="components/file-selects" Orientation="Orientation.Vertical" />
+    </NavGroup>
+
+    <NavGroup Title="Navigation">
+        <Tab Text="@Label("Breadcrumbs")" Icon="icon-ic_fluent_document_chevron_double_20_regular" ActiveIcon="icon-ic_fluent_document_chevron_double_20_filled" Href="components/breadcrumbs" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Menus")" Icon="icon-ic_fluent_text_bullet_list_square_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_square_20_filled" Href="components/menus" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Tab lists")" Icon="icon-ic_fluent_tab_desktop_20_regular" ActiveIcon="icon-ic_fluent_tab_desktop_20_filled" Href="components/tablists" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Trees")" Icon="icon-ic_fluent_text_bullet_list_tree_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_tree_20_filled" Href="components/trees" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Wizards")" Icon="icon-ic_fluent_slide_text_sparkle_20_regular" ActiveIcon="icon-ic_fluent_slide_text_sparkle_20_filled" Href="components/wizards" Orientation="Orientation.Vertical" />
+    </NavGroup>
+
+    <NavGroup Title="Feedback and overlays">
+        <Tab Text="@Label("Dialogs")" Icon="icon-ic_fluent_window_20_regular" ActiveIcon="icon-ic_fluent_window_20_filled" Href="components/dialogs" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Drawers")" Icon="icon-ic_fluent_slide_arrow_right_20_regular" ActiveIcon="icon-ic_fluent_slide_arrow_right_20_filled" Href="components/drawers" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Message bars")" Icon="icon-ic_fluent_info_20_regular" ActiveIcon="icon-ic_fluent_info_20_filled" Href="components/message-bars" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Popovers")" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/popovers" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Toasts")" Icon="icon-ic_fluent_alert_urgent_20_regular" ActiveIcon="icon-ic_fluent_alert_urgent_20_filled" Href="components/toasts" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Tooltips")" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/tooltips" Orientation="Orientation.Vertical" />
+    </NavGroup>
+
+    <NavGroup Title="Data display">
+        <Tab Text="@Label("Data grids")" Icon="icon-ic_fluent_grid_20_regular" ActiveIcon="icon-ic_fluent_grid_20_filled" Href="components/data-grids" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Data pagers")" Icon="icon-ic_fluent_arrow_fit_20_regular" ActiveIcon="icon-ic_fluent_arrow_fit_20_filled" Href="components/data-pagers" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Lists")" Icon="icon-ic_fluent_list_20_regular" ActiveIcon="icon-ic_fluent_list_20_filled" Href="components/lists" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Cards")" Icon="icon-ic_fluent_card_ui_20_regular" ActiveIcon="icon-ic_fluent_card_ui_20_filled" Href="components/cards" Orientation="Orientation.Vertical" />
+    </NavGroup>
+
+    <NavGroup Title="Layout">
+        <Tab Text="@Label("Dock panels")" Icon="icon-ic_fluent_layout_column_two_split_left_20_regular" ActiveIcon="icon-ic_fluent_layout_column_two_split_left_20_filled" Href="components/dock-panels" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Split panels")" Icon="icon-ic_fluent_split_hint_20_regular" ActiveIcon="icon-ic_fluent_split_hint_20_filled" Href="components/split-panels" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Stacks")" Icon="icon-ic_fluent_stack_vertical_20_regular" ActiveIcon="icon-ic_fluent_stack_vertical_20_filled" Href="components/stacks" Orientation="Orientation.Vertical" />
+    </NavGroup>
+
+    <NavGroup Title="Status and visuals">
+        <Tab Text="@Label("Avatars")" Icon="icon-ic_fluent_person_circle_20_regular" ActiveIcon="icon-ic_fluent_person_circle_20_filled" Href="components/avatars" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Badges")" Icon="icon-ic_fluent_badge_20_regular" ActiveIcon="icon-ic_fluent_badge_20_filled" Href="components/badges" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Icons")" Icon="icon-ic_fluent_icons_20_regular" ActiveIcon="icon-ic_fluent_icons_20_filled" Href="components/icons" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Labels")" Icon="icon-ic_fluent_tag_circle_20_regular" ActiveIcon="icon-ic_fluent_tag_circle_20_filled" Href="components/labels" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Tags")" Icon="icon-ic_fluent_tag_20_regular" ActiveIcon="icon-ic_fluent_tag_20_filled" Href="components/tags" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Progress bars")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/progress-bars" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Skeletons")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/skeletons" Orientation="Orientation.Vertical" />
+        <Tab Text="@Label("Spinners")" Icon="icon-ic_fluent_spinner_ios_20_regular" ActiveIcon="icon-ic_fluent_spinner_ios_20_filled" Href="components/spinners" Orientation="Orientation.Vertical" />
+    </NavGroup>
+
+    <NavGroup Title="Rich capabilities">
+        <Tab Text="@Label("Drawing")" Icon="icon-ic_fluent_draw_image_20_regular" ActiveIcon="icon-ic_fluent_draw_image_20_filled" Href="components/drawing-canvases" Orientation="Orientation.Vertical" />
+    </NavGroup>
+</nav>
+
+@code {
     [Parameter] public bool Expanded { get; set; }
 
+    private string Label(string value) => Expanded ? value : string.Empty;
 }

--- a/src/Bluent.UI.Demo.Pages/Layout/Side.razor
+++ b/src/Bluent.UI.Demo.Pages/Layout/Side.razor
@@ -9,13 +9,13 @@
         </TabList>
     </div>
 
-    <NavGroup Title="Actions">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Actions</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Buttons")" Icon="icon-ic_fluent_button_20_regular" ActiveIcon="icon-ic_fluent_button_20_filled" Href="components/buttons" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Links")" Icon="icon-ic_fluent_link_20_regular" ActiveIcon="icon-ic_fluent_link_20_filled" Href="components/links" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Toolbars")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/toolbars" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 
-    <NavGroup Title="Inputs and forms">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Inputs and forms</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Fields")" Icon="icon-ic_fluent_text_field_20_regular" ActiveIcon="icon-ic_fluent_text_field_20_filled" Href="components/fields" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Checkboxes")" Icon="icon-ic_fluent_checkbox_checked_20_regular" ActiveIcon="icon-ic_fluent_checkbox_checked_20_filled" Href="components/checkboxes" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Radio")" Icon="icon-ic_fluent_radio_button_20_regular" ActiveIcon="icon-ic_fluent_radio_button_20_filled" Href="components/radios" Orientation="Orientation.Vertical" />
@@ -23,39 +23,39 @@
         <Tab Text="@Label("Calendar")" Icon="icon-ic_fluent_calendar_20_regular" ActiveIcon="icon-ic_fluent_calendar_20_filled" Href="components/calendars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Sliders")" Icon="icon-ic_fluent_line_flow_diagonal_up_right_20_regular" ActiveIcon="icon-ic_fluent_line_flow_diagonal_up_right_20_filled" Href="components/sliders" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("File selects")" Icon="icon-ic_fluent_attach_20_regular" ActiveIcon="icon-ic_fluent_attach_20_filled" Href="components/file-selects" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 
-    <NavGroup Title="Navigation">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Navigation</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Breadcrumbs")" Icon="icon-ic_fluent_document_chevron_double_20_regular" ActiveIcon="icon-ic_fluent_document_chevron_double_20_filled" Href="components/breadcrumbs" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Menus")" Icon="icon-ic_fluent_text_bullet_list_square_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_square_20_filled" Href="components/menus" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Tab lists")" Icon="icon-ic_fluent_tab_desktop_20_regular" ActiveIcon="icon-ic_fluent_tab_desktop_20_filled" Href="components/tablists" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Trees")" Icon="icon-ic_fluent_text_bullet_list_tree_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_tree_20_filled" Href="components/trees" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Wizards")" Icon="icon-ic_fluent_slide_text_sparkle_20_regular" ActiveIcon="icon-ic_fluent_slide_text_sparkle_20_filled" Href="components/wizards" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 
-    <NavGroup Title="Feedback and overlays">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Feedback and overlays</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Dialogs")" Icon="icon-ic_fluent_window_20_regular" ActiveIcon="icon-ic_fluent_window_20_filled" Href="components/dialogs" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Drawers")" Icon="icon-ic_fluent_slide_arrow_right_20_regular" ActiveIcon="icon-ic_fluent_slide_arrow_right_20_filled" Href="components/drawers" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Message bars")" Icon="icon-ic_fluent_info_20_regular" ActiveIcon="icon-ic_fluent_info_20_filled" Href="components/message-bars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Popovers")" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/popovers" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Toasts")" Icon="icon-ic_fluent_alert_urgent_20_regular" ActiveIcon="icon-ic_fluent_alert_urgent_20_filled" Href="components/toasts" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Tooltips")" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/tooltips" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 
-    <NavGroup Title="Data display">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Data display</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Data grids")" Icon="icon-ic_fluent_grid_20_regular" ActiveIcon="icon-ic_fluent_grid_20_filled" Href="components/data-grids" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Data pagers")" Icon="icon-ic_fluent_arrow_fit_20_regular" ActiveIcon="icon-ic_fluent_arrow_fit_20_filled" Href="components/data-pagers" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Lists")" Icon="icon-ic_fluent_list_20_regular" ActiveIcon="icon-ic_fluent_list_20_filled" Href="components/lists" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Cards")" Icon="icon-ic_fluent_card_ui_20_regular" ActiveIcon="icon-ic_fluent_card_ui_20_filled" Href="components/cards" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 
-    <NavGroup Title="Layout">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Layout</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Dock panels")" Icon="icon-ic_fluent_layout_column_two_split_left_20_regular" ActiveIcon="icon-ic_fluent_layout_column_two_split_left_20_filled" Href="components/dock-panels" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Split panels")" Icon="icon-ic_fluent_split_hint_20_regular" ActiveIcon="icon-ic_fluent_split_hint_20_filled" Href="components/split-panels" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Stacks")" Icon="icon-ic_fluent_stack_vertical_20_regular" ActiveIcon="icon-ic_fluent_stack_vertical_20_filled" Href="components/stacks" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 
-    <NavGroup Title="Status and visuals">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Status and visuals</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Avatars")" Icon="icon-ic_fluent_person_circle_20_regular" ActiveIcon="icon-ic_fluent_person_circle_20_filled" Href="components/avatars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Badges")" Icon="icon-ic_fluent_badge_20_regular" ActiveIcon="icon-ic_fluent_badge_20_filled" Href="components/badges" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Icons")" Icon="icon-ic_fluent_icons_20_regular" ActiveIcon="icon-ic_fluent_icons_20_filled" Href="components/icons" Orientation="Orientation.Vertical" />
@@ -64,11 +64,11 @@
         <Tab Text="@Label("Progress bars")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/progress-bars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Skeletons")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/skeletons" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Spinners")" Icon="icon-ic_fluent_spinner_ios_20_regular" ActiveIcon="icon-ic_fluent_spinner_ios_20_filled" Href="components/spinners" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 
-    <NavGroup Title="Rich capabilities">
+    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Rich capabilities</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Drawing")" Icon="icon-ic_fluent_draw_image_20_regular" ActiveIcon="icon-ic_fluent_draw_image_20_filled" Href="components/drawing-canvases" Orientation="Orientation.Vertical" />
-    </NavGroup>
+        </TabList>\n    </section>
 </nav>
 
 @code {

--- a/src/Bluent.UI.Demo.Pages/Layout/Side.razor
+++ b/src/Bluent.UI.Demo.Pages/Layout/Side.razor
@@ -3,7 +3,7 @@
 <nav class="demo-nav @(Expanded ? "expanded" : "compact")" aria-label="Demo navigation">
     <div class="primary-links">
         <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
-            <Tab Text="@Label("Home")" Icon="icon-ic_fluent_home_20_regular" ActiveIcon="icon-ic_fluent_home_20_filled" Href="/" Orientation="Orientation.Vertical" />
+            <Tab Text="@Label("Home")" Icon="icon-ic_fluent_home_20_regular" ActiveIcon="icon-ic_fluent_home_20_filled" Href="/" Orientation="Orientation.Vertical" />\n            <Tab Text="@Label("Getting started")" Icon="icon-ic_fluent_book_open_20_regular" ActiveIcon="icon-ic_fluent_book_open_20_filled" Href="getting-started" Orientation="Orientation.Vertical" />
             <Tab Text="@Label("Charts")" Icon="icon-ic_fluent_chart_multiple_20_regular" ActiveIcon="icon-ic_fluent_chart_multiple_20_filled" Href="components/charts" Orientation="Orientation.Vertical" />
             <Tab Text="@Label("Diagrams")" Icon="icon-ic_fluent_diagram_20_regular" ActiveIcon="icon-ic_fluent_diagram_20_filled" Href="components/diagrams" Orientation="Orientation.Vertical" />
         </TabList>

--- a/src/Bluent.UI.Demo.Pages/Layout/Side.razor
+++ b/src/Bluent.UI.Demo.Pages/Layout/Side.razor
@@ -3,19 +3,31 @@
 <nav class="demo-nav @(Expanded ? "expanded" : "compact")" aria-label="Demo navigation">
     <div class="primary-links">
         <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
-            <Tab Text="@Label("Home")" Icon="icon-ic_fluent_home_20_regular" ActiveIcon="icon-ic_fluent_home_20_filled" Href="/" Orientation="Orientation.Vertical" />\n            <Tab Text="@Label("Getting started")" Icon="icon-ic_fluent_book_open_20_regular" ActiveIcon="icon-ic_fluent_book_open_20_filled" Href="getting-started" Orientation="Orientation.Vertical" />
+            <Tab Text="@Label("Home")" Icon="icon-ic_fluent_home_20_regular" ActiveIcon="icon-ic_fluent_home_20_filled" Href="/" Orientation="Orientation.Vertical" />
+            <Tab Text="@Label("Getting started")" Icon="icon-ic_fluent_book_open_20_regular" ActiveIcon="icon-ic_fluent_book_open_20_filled" Href="getting-started" Orientation="Orientation.Vertical" />
             <Tab Text="@Label("Charts")" Icon="icon-ic_fluent_chart_multiple_20_regular" ActiveIcon="icon-ic_fluent_chart_multiple_20_filled" Href="components/charts" Orientation="Orientation.Vertical" />
             <Tab Text="@Label("Diagrams")" Icon="icon-ic_fluent_diagram_20_regular" ActiveIcon="icon-ic_fluent_diagram_20_filled" Href="components/diagrams" Orientation="Orientation.Vertical" />
         </TabList>
     </div>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Actions</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Actions</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Buttons")" Icon="icon-ic_fluent_button_20_regular" ActiveIcon="icon-ic_fluent_button_20_filled" Href="components/buttons" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Links")" Icon="icon-ic_fluent_link_20_regular" ActiveIcon="icon-ic_fluent_link_20_filled" Href="components/links" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Toolbars")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/toolbars" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Inputs and forms</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Inputs and forms</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Fields")" Icon="icon-ic_fluent_text_field_20_regular" ActiveIcon="icon-ic_fluent_text_field_20_filled" Href="components/fields" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Checkboxes")" Icon="icon-ic_fluent_checkbox_checked_20_regular" ActiveIcon="icon-ic_fluent_checkbox_checked_20_filled" Href="components/checkboxes" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Radio")" Icon="icon-ic_fluent_radio_button_20_regular" ActiveIcon="icon-ic_fluent_radio_button_20_filled" Href="components/radios" Orientation="Orientation.Vertical" />
@@ -23,39 +35,69 @@
         <Tab Text="@Label("Calendar")" Icon="icon-ic_fluent_calendar_20_regular" ActiveIcon="icon-ic_fluent_calendar_20_filled" Href="components/calendars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Sliders")" Icon="icon-ic_fluent_line_flow_diagonal_up_right_20_regular" ActiveIcon="icon-ic_fluent_line_flow_diagonal_up_right_20_filled" Href="components/sliders" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("File selects")" Icon="icon-ic_fluent_attach_20_regular" ActiveIcon="icon-ic_fluent_attach_20_filled" Href="components/file-selects" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Navigation</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Navigation</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Breadcrumbs")" Icon="icon-ic_fluent_document_chevron_double_20_regular" ActiveIcon="icon-ic_fluent_document_chevron_double_20_filled" Href="components/breadcrumbs" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Menus")" Icon="icon-ic_fluent_text_bullet_list_square_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_square_20_filled" Href="components/menus" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Tab lists")" Icon="icon-ic_fluent_tab_desktop_20_regular" ActiveIcon="icon-ic_fluent_tab_desktop_20_filled" Href="components/tablists" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Trees")" Icon="icon-ic_fluent_text_bullet_list_tree_20_regular" ActiveIcon="icon-ic_fluent_text_bullet_list_tree_20_filled" Href="components/trees" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Wizards")" Icon="icon-ic_fluent_slide_text_sparkle_20_regular" ActiveIcon="icon-ic_fluent_slide_text_sparkle_20_filled" Href="components/wizards" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Feedback and overlays</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Feedback and overlays</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Dialogs")" Icon="icon-ic_fluent_window_20_regular" ActiveIcon="icon-ic_fluent_window_20_filled" Href="components/dialogs" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Drawers")" Icon="icon-ic_fluent_slide_arrow_right_20_regular" ActiveIcon="icon-ic_fluent_slide_arrow_right_20_filled" Href="components/drawers" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Message bars")" Icon="icon-ic_fluent_info_20_regular" ActiveIcon="icon-ic_fluent_info_20_filled" Href="components/message-bars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Popovers")" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/popovers" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Toasts")" Icon="icon-ic_fluent_alert_urgent_20_regular" ActiveIcon="icon-ic_fluent_alert_urgent_20_filled" Href="components/toasts" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Tooltips")" Icon="icon-ic_fluent_tooltip_quote_20_regular" ActiveIcon="icon-ic_fluent_tooltip_quote_20_filled" Href="components/tooltips" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Data display</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Data display</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Data grids")" Icon="icon-ic_fluent_grid_20_regular" ActiveIcon="icon-ic_fluent_grid_20_filled" Href="components/data-grids" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Data pagers")" Icon="icon-ic_fluent_arrow_fit_20_regular" ActiveIcon="icon-ic_fluent_arrow_fit_20_filled" Href="components/data-pagers" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Lists")" Icon="icon-ic_fluent_list_20_regular" ActiveIcon="icon-ic_fluent_list_20_filled" Href="components/lists" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Cards")" Icon="icon-ic_fluent_card_ui_20_regular" ActiveIcon="icon-ic_fluent_card_ui_20_filled" Href="components/cards" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Layout</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Layout</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Dock panels")" Icon="icon-ic_fluent_layout_column_two_split_left_20_regular" ActiveIcon="icon-ic_fluent_layout_column_two_split_left_20_filled" Href="components/dock-panels" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Split panels")" Icon="icon-ic_fluent_split_hint_20_regular" ActiveIcon="icon-ic_fluent_split_hint_20_filled" Href="components/split-panels" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Stacks")" Icon="icon-ic_fluent_stack_vertical_20_regular" ActiveIcon="icon-ic_fluent_stack_vertical_20_filled" Href="components/stacks" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Status and visuals</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Status and visuals</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Avatars")" Icon="icon-ic_fluent_person_circle_20_regular" ActiveIcon="icon-ic_fluent_person_circle_20_filled" Href="components/avatars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Badges")" Icon="icon-ic_fluent_badge_20_regular" ActiveIcon="icon-ic_fluent_badge_20_filled" Href="components/badges" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Icons")" Icon="icon-ic_fluent_icons_20_regular" ActiveIcon="icon-ic_fluent_icons_20_filled" Href="components/icons" Orientation="Orientation.Vertical" />
@@ -64,11 +106,18 @@
         <Tab Text="@Label("Progress bars")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/progress-bars" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Skeletons")" Icon="icon-ic_fluent_apps_20_regular" ActiveIcon="icon-ic_fluent_apps_20_filled" Href="components/skeletons" Orientation="Orientation.Vertical" />
         <Tab Text="@Label("Spinners")" Icon="icon-ic_fluent_spinner_ios_20_regular" ActiveIcon="icon-ic_fluent_spinner_ios_20_filled" Href="components/spinners" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 
-    <section class="nav-group">\n        @if (Expanded)\n        {\n            <h2 class="nav-group-title">Rich capabilities</h2>\n        }\n        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
+    <section class="nav-group">
+        @if (Expanded)
+        {
+            <h2 class="nav-group-title">Rich capabilities</h2>
+        }
+        <TabList Appearance="TabListAppearance.Subtle" Size="TabListSize.Small" Orientation="Orientation.Vertical">
         <Tab Text="@Label("Drawing")" Icon="icon-ic_fluent_draw_image_20_regular" ActiveIcon="icon-ic_fluent_draw_image_20_filled" Href="components/drawing-canvases" Orientation="Orientation.Vertical" />
-        </TabList>\n    </section>
+        </TabList>
+    </section>
 </nav>
 
 @code {

--- a/src/Bluent.UI.Demo.Pages/Layout/Side.razor.css
+++ b/src/Bluent.UI.Demo.Pages/Layout/Side.razor.css
@@ -1,0 +1,48 @@
+.demo-nav {
+    width: 264px;
+    min-height: 100%;
+    padding: .75rem .5rem 1.5rem;
+    transition: width 160ms ease;
+}
+
+.demo-nav.compact {
+    width: 56px;
+}
+
+.primary-links {
+    padding-bottom: .75rem;
+    margin-bottom: .5rem;
+    border-bottom: 1px solid var(--colorNeutralStroke2);
+}
+
+.nav-group {
+    margin-top: .5rem;
+}
+
+.nav-group-title {
+    margin: 0;
+    padding: .75rem .65rem .35rem;
+    color: var(--colorNeutralForeground3);
+    font-size: .7rem;
+    font-weight: 700;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+}
+
+.compact .nav-group {
+    margin-top: .65rem;
+    padding-top: .5rem;
+    border-top: 1px solid var(--colorNeutralStroke2);
+}
+
+@media (max-width: 720px) {
+    .demo-nav.expanded {
+        width: min(82vw, 280px);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .demo-nav {
+        transition: none;
+    }
+}

--- a/src/Bluent.UI.Demo.Pages/Pages/Components/GettingStarted.razor
+++ b/src/Bluent.UI.Demo.Pages/Pages/Components/GettingStarted.razor
@@ -1,10 +1,10 @@
-@page "/getting-started"
+@page "/components/getting-started"
 @namespace Bluent.UI.Demo.Pages.Components
 @using Bluent.UI.Services.Abstractions
 
 <div class="p-5 py-md-10 px-md-12">
     <div class="w-100 w-md-50 m-auto">
-        <h1>Getting started</h1>
+        <h1>Getting started example</h1>
         <p>A small, runnable onboarding example using common Bluent components and the dialog service.</p>
 
         <section class="p-7 rounded-5 shadow-3">

--- a/src/Bluent.UI.Demo.Pages/Pages/GettingStarted.razor
+++ b/src/Bluent.UI.Demo.Pages/Pages/GettingStarted.razor
@@ -1,0 +1,128 @@
+@page "/getting-started"
+
+<PageTitle>Getting Started — Bluent</PageTitle>
+
+<main class="getting-started">
+    <header class="guide-hero">
+        <span class="eyebrow">Getting started</span>
+        <h1>Add Bluent to a Blazor application</h1>
+        <p>
+            Follow the verified WebAssembly onboarding path to install the main package,
+            register its services, load the design system, and render your first component.
+        </p>
+        <div class="guide-meta">
+            <Badge Text=".NET 10" Color="BadgeColor.Brand" />
+            <span>Interactive Blazor application</span>
+            <span>About 5 minutes</span>
+        </div>
+    </header>
+
+    <div class="guide-layout">
+        <aside aria-label="On this page">
+            <strong>On this page</strong>
+            <a href="#install">1. Install</a>
+            <a href="#imports">2. Import</a>
+            <a href="#services">3. Register services</a>
+            <a href="#styles">4. Add styles</a>
+            <a href="#containers">5. Add containers</a>
+            <a href="#component">6. Use a component</a>
+        </aside>
+
+        <article class="guide-content">
+            <section id="install">
+                <span class="step-number">1</span>
+                <div>
+                    <h2>Install the main package</h2>
+                    <p>Run this command from your application project directory.</p>
+                    <pre><code>dotnet add package Bluent.UI</code></pre>
+                    <p class="note">Charts, Diagrams, and Utilities are separate optional packages.</p>
+                </div>
+            </section>
+
+            <section id="imports">
+                <span class="step-number">2</span>
+                <div>
+                    <h2>Import the namespaces</h2>
+                    <p>Add the component and extension namespaces to <code>_Imports.razor</code>.</p>
+                    <pre><code>@@using Bluent.UI.Components
+@@using Bluent.UI.Extensions</code></pre>
+                </div>
+            </section>
+
+            <section id="services">
+                <span class="step-number">3</span>
+                <div>
+                    <h2>Register Bluent services</h2>
+                    <p>Call the registration extension while configuring your application.</p>
+                    <pre><code>using Bluent.UI.Extensions;
+
+builder.Services.AddBluentUI();</code></pre>
+                    <p>
+                        This registers the scoped theme, DOM, dialog, drawer, popover,
+                        toast, tooltip, and dock services used by interactive components.
+                    </p>
+                </div>
+            </section>
+
+            <section id="styles">
+                <span class="step-number">4</span>
+                <div>
+                    <h2>Add the stylesheets</h2>
+                    <p>Add both resources inside the document <code>&lt;head&gt;</code>.</p>
+                    <pre><code>&lt;link href="_content/Bluent.UI/bluent.ui.theme.default.min.css" rel="stylesheet" /&gt;
+&lt;link href="_content/Bluent.UI/bluent.ui.components.min.css" rel="stylesheet" /&gt;</code></pre>
+                </div>
+            </section>
+
+            <section id="containers">
+                <span class="step-number">5</span>
+                <div>
+                    <h2>Add the shared containers</h2>
+                    <p>
+                        Place one container host in the layout wrapping pages that use overlays.
+                        Do not add one to every page.
+                    </p>
+                    <pre><code>@@inherits LayoutComponentBase
+
+&lt;main&gt;
+    @@Body
+&lt;/main&gt;
+
+&lt;Containers /&gt;</code></pre>
+                </div>
+            </section>
+
+            <section id="component">
+                <span class="step-number">6</span>
+                <div>
+                    <h2>Use your first component</h2>
+                    <p>The application is now ready to render Bluent components.</p>
+                    <div class="example-grid">
+                        <pre><code>&lt;Button Text="Save changes"
+        Appearance="ButtonAppearance.Primary"
+        OnClick="Save" /&gt;</code></pre>
+                        <div class="example-preview">
+                            <span>Result</span>
+                            <Button Text="Save changes"
+                                    Appearance="ButtonAppearance.Primary"
+                                    Icon="icon-ic_fluent_save_20_regular"
+                                    ActiveIcon="icon-ic_fluent_save_20_filled" />
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <footer class="next-step">
+                <div>
+                    <span class="eyebrow">Ready to build?</span>
+                    <h2>Explore the component library</h2>
+                    <p>Start with forms, data display, dialogs, charts, or diagrams.</p>
+                </div>
+                <Button Text="Browse components"
+                        Href="components/buttons"
+                        Appearance="ButtonAppearance.Primary"
+                        Size="ButtonSize.Large" />
+            </footer>
+        </article>
+    </div>
+</main>

--- a/src/Bluent.UI.Demo.Pages/Pages/GettingStarted.razor.css
+++ b/src/Bluent.UI.Demo.Pages/Pages/GettingStarted.razor.css
@@ -1,0 +1,203 @@
+.getting-started {
+    width: 100%;
+    padding-bottom: 5rem;
+    color: var(--colorNeutralForeground1);
+}
+
+.guide-hero {
+    padding: clamp(3rem, 7vw, 6rem) clamp(1.5rem, 7vw, 7rem);
+    border-bottom: 1px solid var(--colorNeutralStroke2);
+    background:
+        radial-gradient(circle at 85% 20%, color-mix(in srgb, var(--colorBrandBackground) 16%, transparent), transparent 36%),
+        var(--colorNeutralBackground2);
+}
+
+.eyebrow {
+    color: var(--colorBrandForeground1);
+    font-size: .78rem;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+}
+
+.guide-hero h1 {
+    max-width: 850px;
+    margin: .75rem 0 1rem;
+    font-size: clamp(2.5rem, 5vw, 4.7rem);
+    letter-spacing: -.05em;
+    line-height: 1;
+}
+
+.guide-hero > p {
+    max-width: 720px;
+    color: var(--colorNeutralForeground2);
+    font-size: 1.15rem;
+    line-height: 1.65;
+}
+
+.guide-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .75rem 1.25rem;
+    margin-top: 1.5rem;
+    color: var(--colorNeutralForeground3);
+    font-size: .9rem;
+}
+
+.guide-layout {
+    display: grid;
+    grid-template-columns: 190px minmax(0, 860px);
+    gap: clamp(2rem, 6vw, 6rem);
+    justify-content: center;
+    padding: clamp(2.5rem, 6vw, 5rem) clamp(1.5rem, 7vw, 7rem);
+}
+
+.guide-layout aside {
+    position: sticky;
+    top: 1.5rem;
+    display: flex;
+    align-self: start;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.guide-layout aside strong {
+    margin-bottom: .5rem;
+}
+
+.guide-layout aside a {
+    padding: .35rem 0;
+    color: var(--colorNeutralForeground3);
+    text-decoration: none;
+}
+
+.guide-layout aside a:hover {
+    color: var(--colorBrandForeground1);
+}
+
+.guide-content {
+    min-width: 0;
+}
+
+.guide-content > section {
+    display: grid;
+    grid-template-columns: 2.5rem minmax(0, 1fr);
+    gap: 1rem;
+    padding: 0 0 3.5rem;
+    scroll-margin-top: 2rem;
+}
+
+.step-number {
+    display: grid;
+    width: 2.2rem;
+    height: 2.2rem;
+    place-items: center;
+    border-radius: 50%;
+    color: var(--colorNeutralForegroundOnBrand);
+    background: var(--colorBrandBackground);
+    font-weight: 700;
+}
+
+.guide-content h2 {
+    margin: .15rem 0 .65rem;
+    font-size: 1.65rem;
+}
+
+.guide-content p {
+    color: var(--colorNeutralForeground2);
+    line-height: 1.65;
+}
+
+.guide-content pre {
+    max-width: 100%;
+    margin: 1rem 0;
+    padding: 1.2rem;
+    overflow-x: auto;
+    border: 1px solid var(--colorNeutralStroke2);
+    border-radius: .8rem;
+    color: var(--colorNeutralForeground1);
+    background: var(--colorNeutralBackground3);
+    font-size: .88rem;
+    line-height: 1.6;
+}
+
+.note {
+    padding: .9rem 1rem;
+    border-inline-start: 3px solid var(--colorBrandStroke1);
+    background: var(--colorBrandBackground2);
+}
+
+.example-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(190px, .6fr);
+    gap: 1rem;
+}
+
+.example-grid pre {
+    margin: 0;
+}
+
+.example-preview {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 1rem;
+    padding: 1.25rem;
+    border: 1px solid var(--colorNeutralStroke2);
+    border-radius: .8rem;
+    background: var(--colorNeutralBackground1);
+}
+
+.example-preview > span {
+    color: var(--colorNeutralForeground3);
+    font-size: .78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.next-step {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-top: 1rem;
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+    border-radius: 1.25rem;
+    background: var(--colorNeutralBackground2);
+}
+
+.next-step h2 {
+    margin: .45rem 0;
+}
+
+.next-step p {
+    margin: 0;
+}
+
+@media (max-width: 800px) {
+    .guide-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .guide-layout aside {
+        position: static;
+        display: none;
+    }
+}
+
+@media (max-width: 600px) {
+    .example-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .next-step {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .guide-content > section {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/Bluent.UI.Demo.Pages/Pages/Home.razor
+++ b/src/Bluent.UI.Demo.Pages/Pages/Home.razor
@@ -1,7 +1,129 @@
-﻿@page "/"
+@page "/"
 
-<PageTitle>Home</PageTitle>
+<PageTitle>Bluent — Enterprise Blazor UI</PageTitle>
 
-<h1>Hello, world!</h1>
+<main class="home">
+    <section class="hero">
+        <div class="hero-copy">
+            <span class="eyebrow">Enterprise UI for Blazor</span>
+            <h1>Build polished business applications without rebuilding the design system.</h1>
+            <p class="hero-lead">
+                Bluent is a Fluent-inspired, open-source component toolkit for teams creating
+                capable, self-hosted Blazor applications.
+            </p>
+            <div class="hero-actions">
+                <Button Text="Explore components"
+                        Href="components/buttons"
+                        Appearance="ButtonAppearance.Primary"
+                        Size="ButtonSize.Large"
+                        Icon="icon-ic_fluent_apps_20_regular"
+                        ActiveIcon="icon-ic_fluent_apps_20_filled" />
+                <Button Text="View on GitHub"
+                        Href="https://github.com/vrassouli/Bluent"
+                        Appearance="ButtonAppearance.Outline"
+                        Size="ButtonSize.Large"
+                        Icon="icon-ic_fluent_code_20_regular"
+                        ActiveIcon="icon-ic_fluent_code_20_filled" />
+            </div>
+            <ul class="hero-facts" aria-label="Bluent highlights">
+                <li>Built for modern .NET</li>
+                <li>Dark mode and theme colors</li>
+                <li>LTR and RTL ready</li>
+            </ul>
+        </div>
 
-Welcome to your new app.
+        <div class="hero-preview" aria-label="Example operations workspace">
+            <div class="preview-header">
+                <div>
+                    <span class="preview-kicker">Operations</span>
+                    <strong>Business overview</strong>
+                </div>
+                <Badge Text="Live" Color="BadgeColor.Success" />
+            </div>
+            <div class="metric-grid">
+                <article>
+                    <span>Open requests</span>
+                    <strong>128</strong>
+                    <small>12 need attention</small>
+                </article>
+                <article>
+                    <span>Completion</span>
+                    <strong>94%</strong>
+                    <small>Up 6% this month</small>
+                </article>
+            </div>
+            <div class="preview-list">
+                <div><span class="status status-brand"></span><span>Customer onboarding</span><strong>72%</strong></div>
+                <div><span class="status status-success"></span><span>Contract review</span><strong>Complete</strong></div>
+                <div><span class="status status-warning"></span><span>Compliance checks</span><strong>18 open</strong></div>
+            </div>
+        </div>
+    </section>
+
+    <section class="section" aria-labelledby="capabilities-title">
+        <div class="section-heading">
+            <span class="eyebrow">A practical component system</span>
+            <h2 id="capabilities-title">Everything a serious business UI needs</h2>
+            <p>Compose forms, workflows, dashboards, and rich visual tools from one coherent library.</p>
+        </div>
+        <div class="feature-grid">
+            <a class="feature-card" href="components/fields">
+                <span class="feature-icon icon-ic_fluent_form_20_regular"></span>
+                <h3>Forms and inputs</h3>
+                <p>Fields, validation controls, selectors, calendars, and file inputs for data-heavy workflows.</p>
+                <span class="card-link">Browse form components →</span>
+            </a>
+            <a class="feature-card" href="components/data-grids">
+                <span class="feature-icon icon-ic_fluent_grid_20_regular"></span>
+                <h3>Data and layout</h3>
+                <p>Grids, lists, cards, pagers, stacks, and split layouts for complex application surfaces.</p>
+                <span class="card-link">Explore data display →</span>
+            </a>
+            <a class="feature-card" href="components/dialogs">
+                <span class="feature-icon icon-ic_fluent_window_20_regular"></span>
+                <h3>Feedback and overlays</h3>
+                <p>Dialogs, drawers, popovers, toasts, tooltips, and message bars with shared services.</p>
+                <span class="card-link">See interaction patterns →</span>
+            </a>
+        </div>
+    </section>
+
+    <section class="package-showcase" aria-labelledby="packages-title">
+        <div class="section-heading">
+            <span class="eyebrow">More than base components</span>
+            <h2 id="packages-title">Visualize systems, data, and decisions</h2>
+        </div>
+        <div class="package-grid">
+            <a class="package-card charts" href="components/charts">
+                <span class="package-label">Bluent.UI.Charts</span>
+                <h3>Charts for operational insight</h3>
+                <p>Turn application data into clear, theme-aware visualizations.</p>
+                <span>Explore Charts →</span>
+            </a>
+            <a class="package-card diagrams" href="components/diagrams">
+                <span class="package-label">Bluent.UI.Diagrams</span>
+                <h3>Diagrams for connected workflows</h3>
+                <p>Model relationships and processes directly inside your Blazor application.</p>
+                <span>Explore Diagrams →</span>
+            </a>
+        </div>
+    </section>
+
+    <section class="adapt-section" aria-labelledby="adapt-title">
+        <div>
+            <span class="eyebrow">Designed for real users</span>
+            <h2 id="adapt-title">One interface. Every working context.</h2>
+            <p>
+                Use the controls in the header to switch theme colors, light or dark mode,
+                and LTR or RTL direction. The entire demo adapts immediately.
+            </p>
+        </div>
+        <div class="adapt-pills" aria-label="Adaptive capabilities">
+            <span>Light</span>
+            <span>Dark</span>
+            <span>Theme colors</span>
+            <span>RTL</span>
+            <span>Responsive</span>
+        </div>
+    </section>
+</main>

--- a/src/Bluent.UI.Demo.Pages/Pages/Home.razor
+++ b/src/Bluent.UI.Demo.Pages/Pages/Home.razor
@@ -38,7 +38,7 @@
                     <span class="preview-kicker">Operations</span>
                     <strong>Business overview</strong>
                 </div>
-                <Badge Text="Live" Color="BadgeColor.Success" />
+                <Badge Text="Live" Color="BadgeColor.Brand" />
             </div>
             <div class="metric-grid">
                 <article>

--- a/src/Bluent.UI.Demo.Pages/Pages/Home.razor.css
+++ b/src/Bluent.UI.Demo.Pages/Pages/Home.razor.css
@@ -1,0 +1,337 @@
+.home {
+    color: var(--colorNeutralForeground1);
+    width: 100%;
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(320px, .95fr);
+    gap: clamp(2rem, 6vw, 6rem);
+    align-items: center;
+    min-height: 620px;
+    padding: clamp(3rem, 8vw, 7rem) clamp(1.5rem, 7vw, 7rem);
+    background:
+        radial-gradient(circle at 85% 15%, color-mix(in srgb, var(--colorBrandBackground) 18%, transparent), transparent 38%),
+        linear-gradient(145deg, var(--colorNeutralBackground1), var(--colorNeutralBackground2));
+}
+
+.eyebrow,
+.preview-kicker,
+.package-label {
+    color: var(--colorBrandForeground1);
+    font-size: .78rem;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+}
+
+.hero h1 {
+    max-width: 820px;
+    margin: .8rem 0 1.25rem;
+    font-size: clamp(2.6rem, 5.5vw, 5.2rem);
+    font-weight: 700;
+    letter-spacing: -.055em;
+    line-height: .98;
+}
+
+.hero-lead {
+    max-width: 690px;
+    color: var(--colorNeutralForeground2);
+    font-size: clamp(1.05rem, 1.7vw, 1.35rem);
+    line-height: 1.65;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+    margin-top: 2rem;
+}
+
+.hero-facts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .6rem 1.5rem;
+    margin: 1.8rem 0 0;
+    padding: 0;
+    color: var(--colorNeutralForeground3);
+    font-size: .9rem;
+    list-style: none;
+}
+
+.hero-facts li::before {
+    color: var(--colorPaletteGreenForeground1);
+    content: "✓";
+    margin-inline-end: .45rem;
+    font-weight: 700;
+}
+
+.hero-preview {
+    padding: clamp(1.25rem, 3vw, 2rem);
+    border: 1px solid var(--colorNeutralStroke2);
+    border-radius: 1.5rem;
+    background: color-mix(in srgb, var(--colorNeutralBackground1) 88%, transparent);
+    box-shadow: 0 30px 80px color-mix(in srgb, var(--colorNeutralForeground1) 12%, transparent);
+    transform: rotate(1deg);
+}
+
+.preview-header,
+.preview-list > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.preview-header > div {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: .8rem;
+    margin: 1.5rem 0;
+}
+
+.metric-grid article {
+    display: flex;
+    flex-direction: column;
+    gap: .3rem;
+    padding: 1.15rem;
+    border-radius: 1rem;
+    background: var(--colorNeutralBackground3);
+}
+
+.metric-grid span,
+.metric-grid small {
+    color: var(--colorNeutralForeground3);
+}
+
+.metric-grid strong {
+    font-size: 2rem;
+}
+
+.preview-list {
+    display: flex;
+    flex-direction: column;
+    gap: .65rem;
+}
+
+.preview-list > div {
+    justify-content: flex-start;
+    gap: .7rem;
+    padding: .9rem;
+    border-bottom: 1px solid var(--colorNeutralStroke2);
+}
+
+.preview-list > div:last-child {
+    border-bottom: 0;
+}
+
+.preview-list > div strong {
+    margin-inline-start: auto;
+    font-size: .85rem;
+}
+
+.status {
+    width: .65rem;
+    height: .65rem;
+    border-radius: 50%;
+}
+
+.status-brand { background: var(--colorBrandBackground); }
+.status-success { background: var(--colorPaletteGreenBackground3); }
+.status-warning { background: var(--colorPaletteMarigoldBackground3); }
+
+.section,
+.package-showcase,
+.adapt-section {
+    padding: clamp(3.5rem, 7vw, 7rem) clamp(1.5rem, 7vw, 7rem);
+}
+
+.section-heading {
+    max-width: 720px;
+    margin-bottom: 2rem;
+}
+
+.section-heading h2,
+.adapt-section h2 {
+    margin: .6rem 0 .75rem;
+    font-size: clamp(2rem, 4vw, 3.5rem);
+    letter-spacing: -.04em;
+}
+
+.section-heading p,
+.adapt-section p,
+.feature-card p,
+.package-card p {
+    color: var(--colorNeutralForeground2);
+    line-height: 1.65;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+}
+
+.feature-card,
+.package-card {
+    color: inherit;
+    text-decoration: none;
+    transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.feature-card {
+    min-height: 260px;
+    padding: 1.6rem;
+    border: 1px solid var(--colorNeutralStroke2);
+    border-radius: 1.1rem;
+    background: var(--colorNeutralBackground1);
+}
+
+.feature-card:hover,
+.package-card:hover {
+    border-color: var(--colorBrandStroke1);
+    box-shadow: 0 14px 35px color-mix(in srgb, var(--colorNeutralForeground1) 9%, transparent);
+    transform: translateY(-4px);
+}
+
+.feature-icon {
+    display: inline-grid;
+    width: 2.8rem;
+    height: 2.8rem;
+    place-items: center;
+    border-radius: .8rem;
+    color: var(--colorBrandForeground1);
+    background: var(--colorBrandBackground2);
+    font-size: 1.35rem;
+}
+
+.feature-card h3,
+.package-card h3 {
+    margin: 1.3rem 0 .6rem;
+    font-size: 1.25rem;
+}
+
+.card-link,
+.package-card > span:last-child {
+    display: inline-block;
+    margin-top: 1rem;
+    color: var(--colorBrandForeground1);
+    font-weight: 600;
+}
+
+.package-showcase {
+    background: var(--colorNeutralBackground2);
+}
+
+.package-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+}
+
+.package-card {
+    min-height: 300px;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    overflow: hidden;
+    border: 1px solid var(--colorNeutralStroke2);
+    border-radius: 1.25rem;
+    background: var(--colorNeutralBackground1);
+}
+
+.package-card h3 {
+    max-width: 480px;
+    font-size: clamp(1.7rem, 3vw, 2.6rem);
+}
+
+.package-card p {
+    max-width: 520px;
+}
+
+.charts {
+    background:
+        linear-gradient(135deg, transparent 60%, color-mix(in srgb, var(--colorBrandBackground) 15%, transparent)),
+        var(--colorNeutralBackground1);
+}
+
+.diagrams {
+    background:
+        radial-gradient(circle at 90% 80%, color-mix(in srgb, var(--colorPalettePurpleBackground2) 40%, transparent), transparent 32%),
+        var(--colorNeutralBackground1);
+}
+
+.adapt-section {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+    align-items: center;
+}
+
+.adapt-section > div:first-child {
+    max-width: 680px;
+}
+
+.adapt-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+    justify-content: center;
+}
+
+.adapt-pills span {
+    padding: .8rem 1.1rem;
+    border: 1px solid var(--colorNeutralStroke2);
+    border-radius: 999px;
+    background: var(--colorNeutralBackground3);
+    font-weight: 600;
+}
+
+@media (max-width: 900px) {
+    .hero,
+    .adapt-section {
+        grid-template-columns: 1fr;
+    }
+
+    .hero {
+        min-height: auto;
+    }
+
+    .hero-preview {
+        transform: none;
+    }
+
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 640px) {
+    .package-grid,
+    .metric-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .hero h1 {
+        font-size: 2.55rem;
+    }
+
+    .hero-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .hero-facts {
+        flex-direction: column;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .feature-card,
+    .package-card {
+        transition: none;
+    }
+}


### PR DESCRIPTION
## Summary

Begins Sprint 2 of the Bluent relaunch and establishes a Codex-ready continuation package:

- replaces the default Blazor starter home with a responsive product landing page
- explains Bluent's enterprise positioning and primary capabilities
- elevates themes, dark mode, RTL, Charts, and Diagrams
- reorganizes the flat component list into purpose-based navigation groups
- makes compact/expanded navigation functional
- adds an in-demo Getting Started guide based on canonical source-verified documentation
- adds responsive scoped styles for the landing, navigation, and guide
- adds repository-native agent handoff and execution files

## Codex handoff

- `.bluent/HANDOFF.md` — immediate continuation instructions
- `.bluent/PROJECT.md` — authoritative current status
- `.bluent/sprints/sprint-02.md` — detailed work breakdown and acceptance criteria
- `.bluent/QUALITY.md` — evidence and completion policy
- `.bluent/BACKLOG.md` — future and deferred work
- `src/Bluent.UI.Demo.Pages/AGENTS.md` — scoped demo instructions
- `docs/demo/sprint-2-audit.md` — source audit

## Current scope

This remains intentionally a draft. Enterprise scenario pages and full browser, visual, screenshot, and deployment validation are still pending.

## Validation already recorded

- [x] Restore and Release build
- [x] Tests
- [x] Pack libraries
- [x] Check local Markdown links
- [ ] Desktop and mobile browser validation
- [ ] Light and dark themes
- [ ] LTR and RTL
- [ ] Browser review of Home and Getting Started
- [ ] Enterprise scenarios
- [ ] Professional screenshots
- [ ] Static deployment validation

GitHub Actions run `30150692825` completed successfully before the latest handoff-document commits. Re-run required validation before marking this PR ready.

## Completion

Closes #368 only after the remaining Sprint 2 scope and validation are complete.

Related to #363.