### PR TITLE
Prepare the first protected stable release

### DIFF
--- a/.bluent/BACKLOG.md
+++ b/.bluent/BACKLOG.md
@@ -6,20 +6,17 @@ Use `.bluent/PROJECT.md` for current status and `.bluent/HANDOFF.md` for the imm
 
 ## Now
 
-Work committed to Sprint 3 and tracked by
-[Issue #372](https://github.com/vrassouli/Bluent/issues/372):
+Stable release preparation tracked by
+[Issue #379](https://github.com/vrassouli/Bluent/issues/379):
 
-- Replace the unsafe publication workflow with explicit, validated,
-  artifact-first automation and a dry-run path.
-- Make changelog-derived release notes deterministic.
-- Triage compiler warnings and prevent unexpected additions.
-- Complete or substantially progress Issue #366 render-mode validation.
-- Add practical CI quality gates.
-- Create contributor-ready issues after the foundations expose the remaining
-  small gaps.
+- Audit current published package versions and release prerequisites.
+- Propose an exact stable version without selecting it silently.
+- Reconcile the changelog with the already-published `1.0.366` packages.
+- Validate the five aligned packages and deterministic notes without
+  publication.
+- Open a preparation pull request for maintainer review.
 
-GitHub Pages/static deployment modernization was completed and validated in
-Sprint 2. It is not active backlog work.
+Do not publish packages or create a tag or GitHub Release as part of this work.
 
 ## Next
 

--- a/.bluent/BACKLOG.md
+++ b/.bluent/BACKLOG.md
@@ -12,6 +12,8 @@ Stable release preparation tracked by
 - Audit current published package versions and release prerequisites.
 - Propose an exact stable version without selecting it silently.
 - Reconcile the changelog with the already-published `1.0.366` packages.
+- Correct packaged README image sources for NuGet.org and prevent unsupported
+  sources from passing release validation.
 - Validate the five aligned packages and deterministic notes without
   publication.
 - Open a preparation pull request for maintainer review.

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -4,18 +4,22 @@ This file is the operational entry point for continuing Bluent with Codex or ano
 
 ## Current Objective
 
-Sprint 3 — Release Reliability and Compatibility is complete.
+Prepare the first stable release through the protected Sprint 3 workflow,
+tracked in [Issue #379](https://github.com/vrassouli/Bluent/issues/379).
 
-No new sprint is active. The next maintainer decision is release planning through the new protected workflow.
+The preparation must not publish packages or create a tag or GitHub Release.
 
 ## Current Branch and Tracking
 
 - Base branch: `Dev`
-- Active branch: `Dev`
+- Active branch: `release/stable-release-preparation`
+- Release-preparation issue:
+  [#379](https://github.com/vrassouli/Bluent/issues/379)
+- Preparation pull request: not opened
 - Sprint 3 plan: `.bluent/sprints/sprint-03.md`
 - Sprint issue: [#372](https://github.com/vrassouli/Bluent/issues/372) — completed
 - Sprint completion: [PR #377](https://github.com/vrassouli/Bluent/pull/377) — merged
-- Closeout pull request: [PR #378](https://github.com/vrassouli/Bluent/pull/378)
+- Closeout pull request: [PR #378](https://github.com/vrassouli/Bluent/pull/378) — merged
 - AI-readiness epic: [#363](https://github.com/vrassouli/Bluent/issues/363)
 - Remaining render-mode follow-ups: [#366](https://github.com/vrassouli/Bluent/issues/366)
 - Release audit: `docs/releasing/release-workflow-audit.md`
@@ -31,8 +35,9 @@ No new sprint is active. The next maintainer decision is release planning throug
 7. `RELEASING.md`
 8. `CHANGELOG.md`
 9. `docs/releasing/release-workflow-audit.md`
-10. `docs/quality/compiler-warning-baseline.md`
-11. `docs/compatibility/hosting-and-render-modes.md`
+10. `docs/releasing/stable-release-readiness.md`
+11. `docs/quality/compiler-warning-baseline.md`
+12. `docs/compatibility/hosting-and-render-modes.md`
 
 ## Completed State
 
@@ -51,17 +56,30 @@ Merged through PR #377:
 
 No real tag, GitHub Release, or NuGet publication was created during Sprint 3.
 
-## Next Decision: Release Planning
+## Current Release-Preparation State
 
-Before any production publication, the maintainer must:
+- PRs #377 and #378 are merged and there were no open pull requests when the
+  preparation branch was created from `Dev` commit `23bf85e`.
+- All five packages have a newer published version than the Sprint 3 audit
+  recorded: legacy `master`-push run #366 published aligned `1.0.366` packages
+  on 2026-07-25 before the replacement workflow merged.
+- `1.0.366` is immutable and cannot be reused.
+- The evidence-based recommendation is stable `1.0.367`, pending explicit
+  maintainer approval.
+- No consumer migration is required by the audited post-`1.0.366` changes.
+- The required `nuget-production` environment is not visible in public GitHub
+  metadata. Secret presence cannot be verified through public metadata.
+- The detailed evidence and remaining checks are in
+  `docs/releasing/stable-release-readiness.md`.
 
-1. choose the exact version;
-2. choose preview or stable status;
-3. review and finalize the matching `CHANGELOG.md` section;
-4. create and protect the `nuget-production` GitHub environment;
-5. add `NUGET_API_KEY` to that environment;
-6. create the exact matching `v<version>` tag only after review;
-7. explicitly authorize the production workflow run.
+Before any production publication, the maintainer still must:
+
+1. approve or replace the proposed exact version;
+2. review and finalize the matching `CHANGELOG.md` section;
+3. create and protect the `nuget-production` GitHub environment;
+4. add `NUGET_API_KEY` to that environment;
+5. create the exact matching `v<version>` tag only after review;
+6. explicitly authorize the production workflow run.
 
 Do not infer or invent a release version.
 
@@ -82,7 +100,8 @@ Do not infer or invent a release version.
 
 ## Next Session
 
-1. Start from current `Dev`.
-2. Verify there are no unexpected open release pull requests.
-3. Ask the maintainer to choose the release-planning direction before creating a branch.
-4. Keep release planning separate from deferred compatibility and AI-readiness work.
+1. Commit and push the focused preparation changes.
+2. Open a preparation pull request targeting `Dev`.
+3. Record clean Quality and Release packages workflow evidence.
+4. Leave the pull request open for the maintainer's version and prerequisite
+   decisions.

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -75,10 +75,11 @@ No real tag, GitHub Release, or NuGet publication was created during Sprint 3.
 - The packaged README now uses a NuGet.org-trusted, commit-pinned screenshot
   URL. Release validation checks every packaged README and rejects relative or
   untrusted image sources.
-- PR #380 passed Quality run #30188954331 and Release packages run
-  #30188954356. The downloaded artifact contained exactly five aligned
-  packages, the validation report, and deterministic notes; both publication
-  jobs were skipped.
+- PR #380 commit `927dd20` passed Quality run #30189474232 and Release packages
+  run #30189474228. Downloaded artifact `bluent-0.0.0-ci.378` contained exactly
+  five aligned packages, the validation report, and deterministic notes. Every
+  package README recorded only the five expected trusted image sources; both
+  publication jobs were skipped.
 
 Before any production publication, the maintainer still must:
 

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -72,6 +72,10 @@ No real tag, GitHub Release, or NuGet publication was created during Sprint 3.
   metadata. Secret presence cannot be verified through public metadata.
 - The detailed evidence and remaining checks are in
   `docs/releasing/stable-release-readiness.md`.
+- PR #380 passed Quality run #30188954331 and Release packages run
+  #30188954356. The downloaded artifact contained exactly five aligned
+  packages, the validation report, and deterministic notes; both publication
+  jobs were skipped.
 
 Before any production publication, the maintainer still must:
 
@@ -101,8 +105,8 @@ Do not infer or invent a release version.
 
 ## Next Session
 
-1. Record clean Quality and Release packages workflow evidence for PR #380.
-2. Inspect the uploaded package-validation report and deterministic notes.
-3. Update the issue and PR with final CI evidence.
-4. Leave the pull request open for the maintainer's version and prerequisite
+1. Review PR #380 and approve or replace the proposed exact version `1.0.367`.
+2. Confirm the protected `nuget-production` environment and scoped
+   `NUGET_API_KEY`.
+3. Leave the pull request open until the maintainer's version and prerequisite
    decisions.

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -72,6 +72,9 @@ No real tag, GitHub Release, or NuGet publication was created during Sprint 3.
   metadata. Secret presence cannot be verified through public metadata.
 - The detailed evidence and remaining checks are in
   `docs/releasing/stable-release-readiness.md`.
+- The packaged README now uses a NuGet.org-trusted, commit-pinned screenshot
+  URL. Release validation checks every packaged README and rejects relative or
+  untrusted image sources.
 - PR #380 passed Quality run #30188954331 and Release packages run
   #30188954356. The downloaded artifact contained exactly five aligned
   packages, the validation report, and deterministic notes; both publication
@@ -105,8 +108,9 @@ Do not infer or invent a release version.
 
 ## Next Session
 
-1. Review PR #380 and approve or replace the proposed exact version `1.0.367`.
-2. Confirm the protected `nuget-production` environment and scoped
+1. Review the updated PR #380 workflow evidence for packaged README validation.
+2. Approve or replace the proposed exact version `1.0.367`.
+3. Confirm the protected `nuget-production` environment and scoped
    `NUGET_API_KEY`.
-3. Leave the pull request open until the maintainer's version and prerequisite
+4. Leave the pull request open until the maintainer's version and prerequisite
    decisions.

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -15,7 +15,8 @@ The preparation must not publish packages or create a tag or GitHub Release.
 - Active branch: `release/stable-release-preparation`
 - Release-preparation issue:
   [#379](https://github.com/vrassouli/Bluent/issues/379)
-- Preparation pull request: not opened
+- Preparation pull request:
+  [#380](https://github.com/vrassouli/Bluent/pull/380) — draft
 - Sprint 3 plan: `.bluent/sprints/sprint-03.md`
 - Sprint issue: [#372](https://github.com/vrassouli/Bluent/issues/372) — completed
 - Sprint completion: [PR #377](https://github.com/vrassouli/Bluent/pull/377) — merged
@@ -100,8 +101,8 @@ Do not infer or invent a release version.
 
 ## Next Session
 
-1. Commit and push the focused preparation changes.
-2. Open a preparation pull request targeting `Dev`.
-3. Record clean Quality and Release packages workflow evidence.
+1. Record clean Quality and Release packages workflow evidence for PR #380.
+2. Inspect the uploaded package-validation report and deterministic notes.
+3. Update the issue and PR with final CI evidence.
 4. Leave the pull request open for the maintainer's version and prerequisite
    decisions.

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -222,6 +222,9 @@ or GitHub Release.
   `nuget-production` or the presence of `NUGET_API_KEY`.
 - The changelog now separates changes already shipped in `1.0.366` from the
   proposed `1.0.367` contents.
+- The packaged README now uses a NuGet.org-trusted, commit-pinned screenshot
+  URL, and release validation rejects relative or untrusted image sources in
+  each of the five packages.
 - PR #380 passed Quality run #30188954331 and Release packages dry-run
   #30188954356. The downloaded artifact contained exactly five aligned
   packages, the validation report, and deterministic dry-run notes; publication
@@ -234,6 +237,7 @@ or GitHub Release.
 - [x] Validate a clean consumer against the five non-publish packages.
 - [x] Open the preparation pull request targeting `Dev`.
 - [x] Record clean Quality and Release packages artifact-only workflow runs.
+- [x] Correct and validate NuGet.org-compatible packaged README image sources.
 - [ ] Obtain the maintainer's exact-version decision.
 - [ ] Obtain maintainer confirmation of the protected environment and secret
   prerequisites before any later publication authorization.

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -10,7 +10,7 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 **Current Sprint:** None; Sprint 3 is complete
 **Status:** In progress
 **Working Branch:** `release/stable-release-preparation`
-**Pull Request:** Not opened
+**Pull Request:** [#380](https://github.com/vrassouli/Bluent/pull/380) — draft
 **Tracking Issue:** [#379](https://github.com/vrassouli/Bluent/issues/379)
 
 ## Operational Files
@@ -197,6 +197,8 @@ Known deferred compatibility work remains tracked in Issue #366, including trans
 
 **Branch:** `release/stable-release-preparation`
 
+**Pull Request:** [#380](https://github.com/vrassouli/Bluent/pull/380) — draft
+
 **Status:** In progress
 
 The maintainer selected a stable release through the protected workflow.
@@ -226,7 +228,7 @@ or GitHub Release.
 - [x] Complete and record local build, test, pack, notes, documentation,
   workflow-YAML, whitespace, and focused accessibility validation.
 - [x] Validate a clean consumer against the five non-publish packages.
-- [ ] Open the preparation pull request targeting `Dev`.
+- [x] Open the preparation pull request targeting `Dev`.
 - [ ] Record clean Quality and Release packages artifact-only workflow runs.
 - [ ] Obtain the maintainer's exact-version decision.
 - [ ] Obtain maintainer confirmation of the protected environment and secret

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -6,12 +6,12 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 
 ## Current Phase
 
-**Phase:** Project Relaunch
-**Current Sprint:** Sprint 3 — Release Reliability and Compatibility
-**Status:** Completed
-**Working Branch:** `Dev`
-**Pull Request:** [#377](https://github.com/vrassouli/Bluent/pull/377) — merged
-**Tracking Issue:** [#372](https://github.com/vrassouli/Bluent/issues/372) — completed
+**Phase:** Stable Release Preparation
+**Current Sprint:** None; Sprint 3 is complete
+**Status:** In progress
+**Working Branch:** `release/stable-release-preparation`
+**Pull Request:** Not opened
+**Tracking Issue:** [#379](https://github.com/vrassouli/Bluent/issues/379)
 
 ## Operational Files
 
@@ -20,6 +20,8 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 - `.bluent/QUALITY.md` — validation evidence and completion policy.
 - `.bluent/BACKLOG.md` — current, next, later, and deferred project work.
 - `docs/releasing/release-workflow-audit.md` — Sprint 3 release audit.
+- `docs/releasing/stable-release-readiness.md` — current package evidence,
+  version recommendation, risks, prerequisites, and validation status.
 - `docs/quality/compiler-warning-baseline.md` — zero-warning baseline and triage record.
 - `docs/compatibility/hosting-and-render-modes.md` — evidence-backed compatibility status.
 
@@ -189,17 +191,46 @@ Before a real NuGet release:
 
 Known deferred compatibility work remains tracked in Issue #366, including transient Interactive Server reconnection and exact Interactive Auto renderer-transition instrumentation.
 
-## Next Phase — Release Planning
+## Stable Release Preparation
 
-No new sprint is active.
+**Tracking:** [Issue #379](https://github.com/vrassouli/Bluent/issues/379)
 
-The next maintainer decision is to select the first release through the new process:
+**Branch:** `release/stable-release-preparation`
 
-- choose the exact version and whether it is preview or stable;
-- confirm the five-package publication set;
-- configure the protected production environment and secret;
-- review the versioned changelog section and migration impact;
-- perform an authorized release dry run or production publication.
+**Status:** In progress
+
+The maintainer selected a stable release through the protected workflow.
+Preparation is underway without publishing packages or creating a release tag
+or GitHub Release.
+
+### Current findings
+
+- PRs #377 and #378 are merged, and no pull requests were open when
+  preparation started from `Dev` commit `23bf85e`.
+- The five-package publication set remains `Bluent.UI.Core`, `Bluent.UI`,
+  `Bluent.UI.Charts`, `Bluent.UI.Diagrams`, and `Bluent.UI.Utilities`.
+- Legacy `master`-push workflow run #366 published aligned stable `1.0.366`
+  packages on 2026-07-25 before the protected workflow merged.
+- The recommended successor is stable `1.0.367`, pending explicit maintainer
+  approval. A patch is SemVer-correct because no incompatible public API,
+  behavior, package-boundary, target-framework, or static-asset change was
+  identified.
+- No version-specific consumer migration is required.
+- Public GitHub metadata exposes only `github-pages`; it cannot verify
+  `nuget-production` or the presence of `NUGET_API_KEY`.
+- The changelog now separates changes already shipped in `1.0.366` from the
+  proposed `1.0.367` contents.
+
+### Remaining work
+
+- [x] Complete and record local build, test, pack, notes, documentation,
+  workflow-YAML, whitespace, and focused accessibility validation.
+- [x] Validate a clean consumer against the five non-publish packages.
+- [ ] Open the preparation pull request targeting `Dev`.
+- [ ] Record clean Quality and Release packages artifact-only workflow runs.
+- [ ] Obtain the maintainer's exact-version decision.
+- [ ] Obtain maintainer confirmation of the protected environment and secret
+  prerequisites before any later publication authorization.
 
 Community outreach, new product features, and Sprint 4 remain unstarted until this release decision is made.
 

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -225,10 +225,11 @@ or GitHub Release.
 - The packaged README now uses a NuGet.org-trusted, commit-pinned screenshot
   URL, and release validation rejects relative or untrusted image sources in
   each of the five packages.
-- PR #380 passed Quality run #30188954331 and Release packages dry-run
-  #30188954356. The downloaded artifact contained exactly five aligned
-  packages, the validation report, and deterministic dry-run notes; publication
-  and GitHub Release jobs were skipped.
+- PR #380 commit `927dd20` passed Quality run #30189474232 and Release packages
+  dry-run #30189474228. Downloaded artifact `bluent-0.0.0-ci.378` contained
+  exactly five aligned packages, the validation report, and deterministic
+  dry-run notes. Every packaged README recorded only the five expected trusted
+  image sources; publication and GitHub Release jobs were skipped.
 
 ### Remaining work
 

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -222,6 +222,10 @@ or GitHub Release.
   `nuget-production` or the presence of `NUGET_API_KEY`.
 - The changelog now separates changes already shipped in `1.0.366` from the
   proposed `1.0.367` contents.
+- PR #380 passed Quality run #30188954331 and Release packages dry-run
+  #30188954356. The downloaded artifact contained exactly five aligned
+  packages, the validation report, and deterministic dry-run notes; publication
+  and GitHub Release jobs were skipped.
 
 ### Remaining work
 
@@ -229,7 +233,7 @@ or GitHub Release.
   workflow-YAML, whitespace, and focused accessibility validation.
 - [x] Validate a clean consumer against the five non-publish packages.
 - [x] Open the preparation pull request targeting `Dev`.
-- [ ] Record clean Quality and Release packages artifact-only workflow runs.
+- [x] Record clean Quality and Release packages artifact-only workflow runs.
 - [ ] Obtain the maintainer's exact-version decision.
 - [ ] Obtain maintainer confirmation of the protected environment and secret
   prerequisites before any later publication authorization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ for example `[Bluent.UI.Charts]`. Breaking changes must start with
 
 ### Fixed
 
-- None.
+- Corrected the packaged README screenshot URL for NuGet.org and added release
+  validation that rejects relative or untrusted README image sources.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,47 @@ Entries should identify affected packages when a change is not ecosystem-wide,
 for example `[Bluent.UI.Charts]`. Breaking changes must start with
 `**Breaking:**` and link to migration guidance.
 
+> Proposed stable version: `1.0.367` (pending maintainer approval). The
+> versioned section and release date will be created only after approval.
+
+### Added
+
+- Deterministic, artifact-first release validation with protected NuGet
+  publication and changelog-derived release notes.
+- Reproducible Interactive Server, Interactive WebAssembly, Interactive Auto,
+  and static SSR compatibility probes.
+
+### Changed
+
+- Replaced run-number-based package publication with an explicit SemVer release
+  workflow and an artifact-only dry-run path.
+- Established a zero-warning Release build baseline and durable package,
+  documentation, workflow, and focused accessibility quality gates.
+- Updated render-mode guidance with build and runtime evidence instead of
+  unverified compatibility placeholders.
+
+### Deprecated
+
+- None.
+
+### Removed
+
+- None.
+
+### Fixed
+
+- None.
+
+### Security
+
+- None.
+
+## [1.0.366] - 2026-07-25
+
+This version was published by the legacy `master`-push workflow before the
+protected release workflow was merged. It has no corresponding repository tag
+or GitHub Release.
+
 ### Added
 
 - Enterprise demo scenarios for customer profiles, operations dashboards, and confirmation workflows.
@@ -20,10 +61,6 @@ for example `[Bluent.UI.Charts]`. Breaking changes must start with
 - GitHub issue and pull request templates.
 - Repository-based project relaunch tracking.
 - AI readiness and discoverability initiative tracked in Issue #363.
-- Deterministic, artifact-first release validation with protected NuGet
-  publication and changelog-derived release notes.
-- Reproducible Interactive Server, Interactive WebAssembly, Interactive Auto,
-  and static SSR compatibility probes.
 
 ### Changed
 
@@ -31,10 +68,6 @@ for example `[Bluent.UI.Charts]`. Breaking changes must start with
 - Repositioned Bluent as a Blazor-native toolkit for modern business applications.
 - Rewrote and verified the repository README.
 - Improved NuGet package descriptions, tags, repository links, project links, license metadata, and package README metadata.
-- Replaced run-number-based package publication with an explicit SemVer release
-  workflow and an artifact-only dry-run path.
-- Updated render-mode guidance with build and runtime evidence instead of
-  unverified compatibility placeholders.
 
 ### Deprecated
 
@@ -57,6 +90,8 @@ for example `[Bluent.UI.Charts]`. Breaking changes must start with
 
 ## Release History
 
-Historical releases predate the adoption of this changelog. Existing versions and release notes remain available through [GitHub Releases](https://github.com/vrassouli/Bluent/releases) and NuGet package history.
+Versions before `1.0.366` predate the adoption of this changelog. Their package
+history remains available on NuGet, but the repository has no historical tags
+or GitHub Releases from which complete release notes can be reconstructed.
 
 Future releases will add a dated section here and move the relevant entries from `Unreleased`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Bluent is a Blazor UI toolkit designed for developers building real-world web ap
 
 ## Demo at a glance
 
-[![Bluent product landing page in the light theme](docs/demo/screenshots/landing-light-ltr.jpg)](https://vrassouli.github.io/Bluent/)
+[![Bluent product landing page in the light theme](https://raw.githubusercontent.com/vrassouli/Bluent/56812a0f324a47df51c50e5030cbe696ea3a3e92/docs/demo/screenshots/landing-light-ltr.jpg)](https://vrassouli.github.io/Bluent/)
 
 The demo combines component references with runnable business workflows such as the [operations dashboard](docs/demo/screenshots/operations-dashboard.jpg). See the [Sprint 2 visual gallery](docs/demo/README.md) for the component showcase and validated dark/RTL presentation.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The demo combines component references with runnable business workflows such as 
 | [`Bluent.UI`](https://www.nuget.org/packages/Bluent.UI) | Main component library |
 | [`Bluent.UI.Charts`](https://www.nuget.org/packages/Bluent.UI.Charts) | Chart components |
 | [`Bluent.UI.Diagrams`](https://www.nuget.org/packages/Bluent.UI.Diagrams) | Diagramming components |
-| `Bluent.UI.Utilities` | Shared UI utilities |
+| [`Bluent.UI.Utilities`](https://www.nuget.org/packages/Bluent.UI.Utilities) | Shared UI utilities |
 
 ## Component areas
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ The repository root README remains the short evaluation and installation entry p
 | AI readiness | [`ai/`](ai/benchmark.md) | Maintain benchmark prompts, dated results, scoring, and recurring failure analysis |
 | Quality | [`quality/compiler-warning-baseline.md`](quality/compiler-warning-baseline.md) | Review the accepted compiler-warning baseline and regression policy |
 | Contributor workflow | [../CONTRIBUTING.md](../CONTRIBUTING.md) | Build, test, and contribute to the repository |
-| Releases | [../RELEASING.md](../RELEASING.md), [../CHANGELOG.md](../CHANGELOG.md), and [`releasing/release-workflow-audit.md`](releasing/release-workflow-audit.md) | Prepare releases, understand changes, and review the audited release baseline |
+| Releases | [../RELEASING.md](../RELEASING.md), [../CHANGELOG.md](../CHANGELOG.md), [`releasing/release-workflow-audit.md`](releasing/release-workflow-audit.md), and [`releasing/stable-release-readiness.md`](releasing/stable-release-readiness.md) | Prepare releases, understand changes, and review release-readiness evidence |
 
 Directories are introduced as their first maintained document is added. Empty placeholder directories are intentionally avoided.
 

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -1,0 +1,215 @@
+# Stable release readiness
+
+**Audit date:** 2026-07-26
+
+**Audited branch:** `release/stable-release-preparation`
+
+**Base commit:** `23bf85e35ae85532603812f758a74916eb03fe4d`
+
+**Tracking:** [Issue #379](https://github.com/vrassouli/Bluent/issues/379)
+
+## Decision status
+
+The maintainer selected a stable release through the protected Sprint 3
+workflow. The exact version remains pending maintainer approval.
+
+**Recommendation:** `1.0.367`
+
+No package, tag, or GitHub Release is created by this preparation work.
+
+## Repository reconciliation
+
+- PR [#377](https://github.com/vrassouli/Bluent/pull/377) merged into `Dev` on
+  2026-07-25.
+- PR [#378](https://github.com/vrassouli/Bluent/pull/378) merged into `Dev` on
+  2026-07-25.
+- The GitHub pull-request API returned no open pull requests at audit time.
+- `Dev` resolved to `23bf85e35ae85532603812f758a74916eb03fe4d`
+  before this branch was created.
+- The publication set remains exactly five packages:
+  `Bluent.UI.Core`, `Bluent.UI`, `Bluent.UI.Charts`,
+  `Bluent.UI.Diagrams`, and `Bluent.UI.Utilities`.
+
+## Published package evidence
+
+NuGet's official V2 package endpoints were queried for each exact package and
+version. The V3 flat-container requests timed out during TLS negotiation in the
+local environment, so the successful V2 results are the recorded evidence.
+
+| Package | Latest verified version | Published (UTC) | Direct Bluent dependency |
+| --- | --- | --- | --- |
+| `Bluent.UI.Core` | `1.0.366` | 2026-07-25 13:05:56 | None |
+| `Bluent.UI` | `1.0.366` | 2026-07-25 13:05:56 | `Bluent.UI.Core` `1.0.366` |
+| `Bluent.UI.Charts` | `1.0.366` | 2026-07-25 13:05:56 | `Bluent.UI.Core` `1.0.366` |
+| `Bluent.UI.Diagrams` | `1.0.366` | 2026-07-25 13:05:57 | `Bluent.UI.Core` `1.0.366` |
+| `Bluent.UI.Utilities` | `1.0.366` | 2026-07-25 13:05:57 | `Bluent.UI` `1.0.366` |
+
+GitHub Actions run
+[#30159062898](https://github.com/vrassouli/Bluent/actions/runs/30159062898)
+was legacy publish workflow run number 366. It was triggered by a push to
+`master` at commit `9056d1c5b3b9f0d714854da0a1712efa55fd3ed8` and completed
+successfully immediately before Sprint 3 replaced that workflow. The commit's
+tree is identical to Sprint 3's starting `Dev` commit
+`864f0d308775e4fdebacc1c12504a098ad1cc73c`.
+
+Consequences:
+
+- `1.0.366` is immutable and cannot be the candidate version.
+- It was published before the protected workflow existed.
+- It has no repository tag or GitHub Release.
+- Its already-shipped changes are now recorded in the dated `1.0.366`
+  changelog section instead of being attributed to the next release.
+
+## Version recommendation
+
+### Proposed exact version
+
+`1.0.367`, pending explicit maintainer approval.
+
+### SemVer justification
+
+- All five packages are already on the stable `1.0.x` line.
+- `1.0.366` is the highest verified published version for every package.
+- Changes since the `1.0.366` package tree add release and quality
+  infrastructure, compatibility evidence, and warning fixes intended to
+  preserve existing behavior.
+- There is no approved incompatible public API, behavior, package-boundary,
+  target-framework, or static-asset change.
+
+A patch increment to `1.0.367` is therefore the smallest SemVer-correct
+successor. A minor or major increment would overstate the compatibility impact.
+
+### Why stable rather than preview
+
+- The maintainer explicitly selected the stable channel.
+- Consumers already use stable `1.0.x` packages; a preview suffix would move
+  the release onto a less stable channel without a corresponding experimental
+  API or compatibility change.
+- Sprint 3 established a zero-warning build, full tests, aligned package
+  validation, deterministic notes, and an artifact-only dry-run path.
+
+### Migration impact
+
+No version-specific consumer migration is required by the audited changes.
+Consumers should update directly installed Bluent packages together to keep
+their versions aligned. The canonical setup, namespaces, service registration,
+container, and asset paths remain unchanged.
+
+### Risks
+
+- This would be the first production use of the replacement workflow.
+- The required `nuget-production` environment is not visible through public
+  GitHub metadata.
+- The presence or value of `NUGET_API_KEY` cannot be verified through public
+  GitHub metadata and must remain a maintainer-owned prerequisite.
+- NuGet cannot publish five packages atomically. Preflight and dependency-order
+  publication reduce, but cannot eliminate, partial-publication risk.
+- The dated `1.0.367` changelog section must not be created until the
+  maintainer approves the version and release date.
+- The final preparation commit still requires an artifact-only GitHub Actions
+  dry run from the preparation head.
+
+## Package and metadata audit
+
+Current source and the release validator agree on these exact relationships:
+
+| Package | Internal dependency required at the exact release version |
+| --- | --- |
+| `Bluent.UI.Core` | None |
+| `Bluent.UI` | `Bluent.UI.Core` |
+| `Bluent.UI.Charts` | `Bluent.UI.Core` |
+| `Bluent.UI.Diagrams` | `Bluent.UI.Core` |
+| `Bluent.UI.Utilities` | `Bluent.UI` |
+
+All five projects target `net10.0`, identify the Git repository, use the
+Apache-2.0 license expression, and package the repository README. The release
+workflow overrides all five package versions together and validates exact
+internal dependency versions. Applications normally install feature packages
+and allow NuGet to resolve Core transitively.
+
+The root README, canonical Getting Started guide, package guidance, migration
+guidance, project metadata, and release workflow agree on package names and
+setup. This preparation adds the missing NuGet link for
+`Bluent.UI.Utilities` in the root README.
+
+## Changelog and migration audit
+
+The previous `Unreleased` section mixed changes already shipped in `1.0.366`
+with post-`1.0.366` work. It was not suitable as `1.0.367` release notes.
+
+This preparation:
+
+- moves the already-shipped entries into a dated `1.0.366` section;
+- records the absence of a corresponding tag and GitHub Release;
+- keeps post-`1.0.366` release, quality, and compatibility work under
+  `Unreleased`;
+- marks `1.0.367` as a proposal pending approval.
+
+No breaking entry or version-specific migration guide is required.
+
+## Workflow and repository prerequisites
+
+No additional repository-side workflow code change was identified. The
+replacement workflow already:
+
+- accepts an explicit SemVer;
+- prevents pull-request publication;
+- requires an exact matching `v<version>` tag for publishing;
+- builds and tests before packing;
+- validates exactly five aligned packages and their metadata;
+- generates deterministic changelog notes;
+- preflights all five immutable NuGet versions;
+- publishes through `nuget-production`;
+- creates a GitHub Release only after NuGet publication.
+
+Public GitHub metadata currently exposes only the `github-pages` environment.
+It exposes no repository tags or GitHub Releases. Public metadata cannot reveal
+whether a secret exists. The maintainer must therefore confirm all of the
+following before any production action:
+
+- [ ] Approve or replace the proposed exact version `1.0.367`.
+- [ ] Create and protect `nuget-production`.
+- [ ] Add the scoped `NUGET_API_KEY` environment secret.
+- [ ] Review the final dated changelog section.
+- [ ] Review the five dry-run packages and validation report.
+- [ ] Authorize creation of the matching annotated tag.
+- [ ] Authorize the production workflow run.
+
+## Validation record
+
+Local environment: macOS 26.5, Apple Silicon, .NET SDK 10.0.300, and .NET
+runtime 10.0.8.
+
+| Check | Result |
+| --- | --- |
+| `dotnet tool restore` | Passed |
+| `dotnet restore Bluent.sln` | Canceled after prolonged NuGet network inactivity; no restore completion is claimed |
+| Release build with `--no-restore -warnaserror` | Passed with 0 warnings and 0 errors using the previously restored assets |
+| Full solution tests | Passed 19/19 |
+| Release-tool tests | Passed 4/4 |
+| Five-package pack | Passed at non-publish version `1.0.367-validation.1` |
+| Package validation | Passed IDs, aligned versions, metadata, README, license, `net10.0`, static assets, repository commit, and exact internal dependencies |
+| Deterministic notes | Passed from `Unreleased`, with the required dry-run notice |
+| Clean Blazor WebAssembly consumer | Passed restore and zero-warning Release build with `Bluent.UI`, Charts, Diagrams, and Utilities directly referenced; Core resolved transitively |
+| Markdown links | Passed across 34 maintained files |
+| Workflow YAML | All three workflow files parsed |
+| Focused rendered accessibility | Passed four compatibility routes; not a WCAG conformance claim |
+| Whitespace | `git diff --check origin/Dev` passed |
+| Candidate availability | Official NuGet V2 endpoints returned HTTP 404 for `1.0.367` on all five package IDs |
+
+The first clean-consumer attempt used `/tmp`, which is a symlink to
+`/private/tmp` on this Mac. Razor source generation failed to resolve the
+template's own `Layout` namespace. An otherwise package-free control template
+failed identically, proving the failure was not introduced by Bluent. Repeating
+the control and Bluent consumers using the canonical `/private/tmp` path
+passed. Both the failed attempt and the controlled result are retained here.
+
+The package validation report and generated notes were inspected in the
+temporary validation directory. No package was pushed to NuGet.
+
+The following checks remain pending until the branch can be committed, pushed,
+and opened as a pull request:
+
+- [ ] Quality workflow on the exact preparation commit.
+- [ ] Release packages artifact-only workflow on the exact preparation commit.
+- [ ] Inspection of the uploaded package report and release notes.

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -8,6 +8,8 @@
 
 **Tracking:** [Issue #379](https://github.com/vrassouli/Bluent/issues/379)
 
+**Preparation PR:** [#380](https://github.com/vrassouli/Bluent/pull/380)
+
 ## Decision status
 
 The maintainer selected a stable release through the protected Sprint 3

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -230,22 +230,24 @@ pushed to NuGet.
 
 ## GitHub Actions evidence
 
-PR #380 head `7f6bad8d8b589b216d04544142fd732cfa5476ee` produced:
+PR #380 head `927dd201638ba812c021ee42748fad61dd87ad3d` produced:
 
-- [Quality run #30188954331](https://github.com/vrassouli/Bluent/actions/runs/30188954331),
+- [Quality run #30189474232](https://github.com/vrassouli/Bluent/actions/runs/30189474232),
   which passed the build, tests, five-package inspection, links, workflow YAML,
   whitespace, and focused accessibility smoke.
-- [Release packages run #30188954356](https://github.com/vrassouli/Bluent/actions/runs/30188954356),
+- [Release packages run #30189474228](https://github.com/vrassouli/Bluent/actions/runs/30189474228),
   whose artifact-validation job passed. The NuGet publication and GitHub
   Release jobs were skipped as designed.
 
-The downloaded `bluent-0.0.0-ci.376` artifact contained exactly five packages,
+The downloaded `bluent-0.0.0-ci.378` artifact contained exactly five packages,
 `release/package-validation.json`, and `release/release-notes.md`. The report
 records the pull-request merge ref commit
-`97863aaa731bb9c8676a77336006c338767d9b4b`, aligned version
-`0.0.0-ci.376`, the expected internal dependency graph, and expected static
-assets. Each package nuspec contains that same repository commit. The notes are
-a deterministic `Unreleased` preview with the required dry-run warning and the
+`0a79c805d9be8d934d078103ee985e7ffff51114`, aligned version
+`0.0.0-ci.378`, the expected internal dependency graph, expected static assets,
+and the same five trusted README image sources for every package. Each package
+nuspec contains that same repository commit. Direct inspection of all five
+archived README files passed the trusted-source validator. The notes are a
+deterministic `Unreleased` preview with the required dry-run warning and the
 pending `1.0.367` recommendation.
 
 No publication job ran, and no external release state changed.

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -209,9 +209,24 @@ passed. Both the failed attempt and the controlled result are retained here.
 The package validation report and generated notes were inspected in the
 temporary validation directory. No package was pushed to NuGet.
 
-The following checks remain pending until the branch can be committed, pushed,
-and opened as a pull request:
+## GitHub Actions evidence
 
-- [ ] Quality workflow on the exact preparation commit.
-- [ ] Release packages artifact-only workflow on the exact preparation commit.
-- [ ] Inspection of the uploaded package report and release notes.
+PR #380 head `7f6bad8d8b589b216d04544142fd732cfa5476ee` produced:
+
+- [Quality run #30188954331](https://github.com/vrassouli/Bluent/actions/runs/30188954331),
+  which passed the build, tests, five-package inspection, links, workflow YAML,
+  whitespace, and focused accessibility smoke.
+- [Release packages run #30188954356](https://github.com/vrassouli/Bluent/actions/runs/30188954356),
+  whose artifact-validation job passed. The NuGet publication and GitHub
+  Release jobs were skipped as designed.
+
+The downloaded `bluent-0.0.0-ci.376` artifact contained exactly five packages,
+`release/package-validation.json`, and `release/release-notes.md`. The report
+records the pull-request merge ref commit
+`97863aaa731bb9c8676a77336006c338767d9b4b`, aligned version
+`0.0.0-ci.376`, the expected internal dependency graph, and expected static
+assets. Each package nuspec contains that same repository commit. The notes are
+a deterministic `Unreleased` preview with the required dry-run warning and the
+pending `1.0.367` recommendation.
+
+No publication job ran, and no external release state changed.

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -108,8 +108,9 @@ container, and asset paths remain unchanged.
   publication reduce, but cannot eliminate, partial-publication risk.
 - The dated `1.0.367` changelog section must not be created until the
   maintainer approves the version and release date.
-- The final preparation commit still requires an artifact-only GitHub Actions
-  dry run from the preparation head.
+- The already-published `1.0.366` package README cannot be edited in place, so
+  its unsupported-image warning remains until a corrected version is
+  published.
 
 ## Package and metadata audit
 
@@ -134,6 +135,19 @@ guidance, project metadata, and release workflow agree on package names and
 setup. This preparation adds the missing NuGet link for
 `Bluent.UI.Utilities` in the root README.
 
+The README packed into all five `1.0.366` packages contains a relative landing
+screenshot path. NuGet.org does not render relative images and reports an
+owner-visible unsupported-image warning. This preparation replaces that source
+with an HTTPS `raw.githubusercontent.com` URL pinned to commit
+`56812a0f324a47df51c50e5030cbe696ea3a3e92`, where the verified screenshot is
+immutable. The existing `img.shields.io` badges already use a trusted host.
+
+The package validator now reads the actual README from each of the five
+archives, records its image sources, and rejects relative paths, non-HTTPS
+sources, and hosts outside NuGet.org's documented allowlist. The published
+`1.0.366` packages are immutable; the package-page warning can disappear only
+after a corrected new version is published.
+
 ## Changelog and migration audit
 
 The previous `Unreleased` section mixed changes already shipped in `1.0.366`
@@ -151,14 +165,16 @@ No breaking entry or version-specific migration guide is required.
 
 ## Workflow and repository prerequisites
 
-No additional repository-side workflow code change was identified. The
-replacement workflow already:
+The package validator required one additional release-safety check for
+NuGet.org-compatible README images. With that check added, the replacement
+workflow:
 
 - accepts an explicit SemVer;
 - prevents pull-request publication;
 - requires an exact matching `v<version>` tag for publishing;
 - builds and tests before packing;
 - validates exactly five aligned packages and their metadata;
+- validates every packaged README image against NuGet.org's trusted sources;
 - generates deterministic changelog notes;
 - preflights all five immutable NuGet versions;
 - publishes through `nuget-production`;
@@ -188,9 +204,9 @@ runtime 10.0.8.
 | `dotnet restore Bluent.sln` | Canceled after prolonged NuGet network inactivity; no restore completion is claimed |
 | Release build with `--no-restore -warnaserror` | Passed with 0 warnings and 0 errors using the previously restored assets |
 | Full solution tests | Passed 19/19 |
-| Release-tool tests | Passed 4/4 |
-| Five-package pack | Passed at non-publish version `1.0.367-validation.1` |
-| Package validation | Passed IDs, aligned versions, metadata, README, license, `net10.0`, static assets, repository commit, and exact internal dependencies |
+| Release-tool tests | Passed 6/6, including trusted and rejected README image sources |
+| Five-package pack | Passed at non-publish version `1.0.367-validation.2` |
+| Package validation | Passed IDs, aligned versions, metadata, README, trusted README image sources, license, `net10.0`, static assets, repository commit, and exact internal dependencies |
 | Deterministic notes | Passed from `Unreleased`, with the required dry-run notice |
 | Clean Blazor WebAssembly consumer | Passed restore and zero-warning Release build with `Bluent.UI`, Charts, Diagrams, and Utilities directly referenced; Core resolved transitively |
 | Markdown links | Passed across 34 maintained files |
@@ -207,7 +223,10 @@ the control and Bluent consumers using the canonical `/private/tmp` path
 passed. Both the failed attempt and the controlled result are retained here.
 
 The package validation report and generated notes were inspected in the
-temporary validation directory. No package was pushed to NuGet.
+temporary validation directory. Each of the five package records contains the
+four `img.shields.io` badges and the commit-pinned `raw.githubusercontent.com`
+screenshot, with no relative or unsupported image source. No package was
+pushed to NuGet.
 
 ## GitHub Actions evidence
 

--- a/llms.txt
+++ b/llms.txt
@@ -33,6 +33,7 @@ Bluent is open source under Apache License 2.0. The current repository targets .
 - [Release policy](https://github.com/vrassouli/Bluent/blob/Dev/RELEASING.md): Semantic Versioning, validation, tagging, and publication
 - [Changelog](https://github.com/vrassouli/Bluent/blob/Dev/CHANGELOG.md): notable changes and release history
 - [Release workflow audit](https://github.com/vrassouli/Bluent/blob/Dev/docs/releasing/release-workflow-audit.md): audited version sources, publication history, workflow risks, and required controls
+- [Stable release readiness](https://github.com/vrassouli/Bluent/blob/Dev/docs/releasing/stable-release-readiness.md): current package evidence, proposed version, migration impact, risks, and maintainer prerequisites
 - [Compiler warning baseline](https://github.com/vrassouli/Bluent/blob/Dev/docs/quality/compiler-warning-baseline.md): warning inventory, dispositions, and zero-warning regression policy
 - [Coding-agent instructions](https://github.com/vrassouli/Bluent/blob/Dev/AGENTS.md): repository facts, guardrails, build commands, and documentation rules
 

--- a/scripts/release/release_tools.py
+++ b/scripts/release/release_tools.py
@@ -10,7 +10,9 @@ import sys
 import urllib.error
 import urllib.request
 import zipfile
+from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import urlsplit
 from xml.etree import ElementTree
 
 
@@ -27,6 +29,81 @@ SEMVER_PATTERN = re.compile(
     r"(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)"
     r"(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?$"
 )
+
+# Keep this list aligned with NuGet.org's documented trusted image hosts:
+# https://learn.microsoft.com/nuget/nuget-org/package-readme-on-nuget-org
+NUGET_TRUSTED_IMAGE_HOSTS = frozenset(
+    {
+        "api.codacy.com",
+        "api.codeclimate.com",
+        "api.dependabot.com",
+        "api.reuse.software",
+        "api.travis-ci.com",
+        "app.codacy.com",
+        "app.deepsource.com",
+        "avatars.githubusercontent.com",
+        "badgen.net",
+        "badges.gitter.im",
+        "camo.githubusercontent.com",
+        "caniuse.bitsofco.de",
+        "cdn.jsdelivr.net",
+        "cdn.syncfusion.com",
+        "ci.appveyor.com",
+        "circleci.com",
+        "cloudback.it",
+        "codecov.io",
+        "codefactor.io",
+        "coveralls.io",
+        "dev.azure.com",
+        "devpod.sh",
+        "flat.badgen.net",
+        "gitlab.com",
+        "i.imgur.com",
+        "img.shields.io",
+        "infragistics.com",
+        "isitmaintained.com",
+        "media.githubusercontent.com",
+        "opencollective.com",
+        "raw.github.com",
+        "raw.githubusercontent.com",
+        "snyk.io",
+        "sonarcloud.io",
+        "travis-ci.com",
+        "travis-ci.org",
+        "user-images.githubusercontent.com",
+    }
+)
+
+MARKDOWN_IMAGE_PATTERN = re.compile(
+    r"!\[[^\]]*\]\(\s*(?:<(?P<angled>[^>]+)>|(?P<plain>[^\s)]+))",
+    re.MULTILINE,
+)
+REFERENCE_DEFINITION_PATTERN = re.compile(
+    r"^[ \t]{0,3}\[(?P<label>[^\]]+)\]:[ \t]*"
+    r"(?:<(?P<angled>[^>\n]+)>|(?P<plain>\S+))",
+    re.MULTILINE,
+)
+REFERENCE_IMAGE_PATTERN = re.compile(
+    r"!\[(?P<alt>[^\]]*)\]\[(?P<label>[^\]]*)\]"
+)
+SHORTCUT_IMAGE_PATTERN = re.compile(
+    r"!\[(?P<label>[^\]]+)\](?![ \t]*(?:\(|\[))"
+)
+
+
+class ReadmeImageParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sources: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        if tag.lower() != "img":
+            return
+        for name, value in attrs:
+            if name.lower() == "src" and value:
+                self.sources.append(value.strip())
 
 
 def fail(message: str) -> None:
@@ -107,6 +184,82 @@ def nuspec_root(package: Path) -> ElementTree.Element:
 def child_text(metadata: ElementTree.Element, name: str) -> str:
     element = metadata.find(f"{{*}}{name}")
     return "" if element is None or element.text is None else element.text.strip()
+
+
+def readme_image_sources(readme: str) -> list[str]:
+    sources = [
+        match.group("angled") or match.group("plain")
+        for match in MARKDOWN_IMAGE_PATTERN.finditer(readme)
+    ]
+    references = {
+        " ".join(match.group("label").split()).casefold(): (
+            match.group("angled") or match.group("plain")
+        )
+        for match in REFERENCE_DEFINITION_PATTERN.finditer(readme)
+    }
+    unresolved: list[str] = []
+    for match in REFERENCE_IMAGE_PATTERN.finditer(readme):
+        label = match.group("label") or match.group("alt")
+        normalized = " ".join(label.split()).casefold()
+        if normalized not in references:
+            unresolved.append(label)
+        else:
+            sources.append(references[normalized])
+    for match in SHORTCUT_IMAGE_PATTERN.finditer(readme):
+        label = match.group("label")
+        normalized = " ".join(label.split()).casefold()
+        if normalized not in references:
+            unresolved.append(label)
+        else:
+            sources.append(references[normalized])
+    if unresolved:
+        fail(
+            "README contains unresolved image references: "
+            f"{', '.join(sorted(set(unresolved)))}."
+        )
+    parser = ReadmeImageParser()
+    parser.feed(readme)
+    sources.extend(parser.sources)
+    return sources
+
+
+def is_nuget_trusted_image_url(source: str) -> bool:
+    try:
+        parsed = urlsplit(source)
+        port = parsed.port
+    except ValueError:
+        return False
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+    ):
+        return False
+    host = parsed.hostname.lower()
+    if host in NUGET_TRUSTED_IMAGE_HOSTS:
+        return True
+    if host != "github.com":
+        return False
+    return re.fullmatch(
+        r"/[^/]+/[^/]+/(?:actions/)?workflows/[^/]+/badge\.svg",
+        parsed.path,
+        re.IGNORECASE,
+    ) is not None
+
+
+def validate_readme_images(readme: str, package_id: str) -> list[str]:
+    sources = readme_image_sources(readme)
+    unsupported = [
+        source for source in sources if not is_nuget_trusted_image_url(source)
+    ]
+    if unsupported:
+        fail(
+            f"{package_id} README contains image sources that NuGet.org will "
+            f"not render: {', '.join(unsupported)}."
+        )
+    return sources
 
 
 def validate_packages(args: argparse.Namespace) -> None:
@@ -195,8 +348,14 @@ def validate_packages(args: argparse.Namespace) -> None:
 
         with zipfile.ZipFile(package) as archive:
             names = set(archive.namelist())
-            if "README.md" not in names:
-                fail(f"{package_id} does not contain README.md.")
+            readme_path = required_fields["readme"]
+            if readme_path not in names:
+                fail(f"{package_id} does not contain {readme_path}.")
+            try:
+                readme = archive.read(readme_path).decode("utf-8-sig")
+            except UnicodeDecodeError:
+                fail(f"{package_id} {readme_path} is not valid UTF-8.")
+            image_sources = validate_readme_images(readme, package_id)
             if not any(
                 name.startswith("lib/net10.0/") and name.endswith(".dll")
                 for name in names
@@ -215,6 +374,7 @@ def validate_packages(args: argparse.Namespace) -> None:
                     dependency: sorted(dependency_versions[dependency])
                     for dependency in sorted(expected_internal)
                 },
+                "readme_image_sources": image_sources,
                 "static_web_asset_count": len(static_assets),
             }
         )

--- a/scripts/release/test_release_tools.py
+++ b/scripts/release/test_release_tools.py
@@ -56,6 +56,40 @@ Historical prose.
                     )
                 )
 
+    def test_accepts_nuget_trusted_readme_image_sources(self) -> None:
+        readme = """\
+![NuGet](https://img.shields.io/nuget/v/Bluent.UI.svg)
+![Demo](https://raw.githubusercontent.com/owner/repo/commit/demo.jpg)
+![Build][build-badge]
+<img src="https://i.imgur.com/example.png" alt="Example">
+
+[build-badge]: https://github.com/owner/repo/actions/workflows/build.yml/badge.svg
+"""
+        self.assertEqual(
+            release_tools.validate_readme_images(readme, "Bluent.UI"),
+            [
+                "https://img.shields.io/nuget/v/Bluent.UI.svg",
+                "https://raw.githubusercontent.com/owner/repo/commit/demo.jpg",
+                "https://github.com/owner/repo/actions/workflows/build.yml/badge.svg",
+                "https://i.imgur.com/example.png",
+            ],
+        )
+
+    def test_rejects_unsupported_readme_image_sources(self) -> None:
+        sources = (
+            "docs/demo.jpg",
+            "http://img.shields.io/example.svg",
+            "https://example.com/example.png",
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                with self.assertRaisesRegex(
+                    ValueError, "NuGet.org will not render"
+                ):
+                    release_tools.validate_readme_images(
+                        f"![Example]({source})", "Bluent.UI"
+                    )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Outcome

Prepares Bluent for its first stable release through the protected Sprint 3 workflow without publishing packages or creating a tag or GitHub Release.

Tracks #379.

## Version recommendation

Recommend **`1.0.367` stable**, pending explicit maintainer approval.

- NuGet confirms aligned stable `1.0.366` packages already exist for all five package IDs.
- Legacy `master`-push workflow [run #366](https://github.com/vrassouli/Bluent/actions/runs/30159062898) published those packages from commit `9056d1c` immediately before Sprint 3 replaced the workflow.
- `1.0.366` is immutable and cannot be reused.
- Changes since that package tree add release/quality infrastructure, compatibility evidence, and behavior-preserving warning fixes. No incompatible public API, behavior, package-boundary, target-framework, or static-asset change was identified.
- A patch increment is SemVer-correct; a preview suffix would contradict the selected stable channel without an experimental compatibility change.

No version-specific consumer migration is required. Directly installed Bluent packages should continue to be upgraded together.

## Exact files changed

- `.bluent/BACKLOG.md`
- `.bluent/HANDOFF.md`
- `.bluent/PROJECT.md`
- `CHANGELOG.md`
- `README.md`
- `scripts/release/release_tools.py`
- `scripts/release/test_release_tools.py`
- `docs/README.md`
- `docs/releasing/stable-release-readiness.md`
- `llms.txt`

## Preparation changes

- Adds the stable-release readiness audit with package history, version rationale, metadata/dependency evidence, migration impact, risks, and maintainer prerequisites.
- Moves changes already shipped in `1.0.366` out of `Unreleased` into a dated section and records the absence of a corresponding tag and GitHub Release.
- Marks `1.0.367` as proposed and pending approval; no dated `1.0.367` section is created.
- Updates project tracking and canonical documentation indexes.
- Adds the missing NuGet link for `Bluent.UI.Utilities` in the root README.
- Replaces the packaged README's relative screenshot with a NuGet.org-trusted, commit-pinned URL.
- Validates every image source in each of the five packaged READMEs and rejects relative, non-HTTPS, unresolved-reference, or unsupported-host sources.

## Local validation

Environment: macOS 26.5, Apple Silicon, .NET SDK 10.0.300, runtime 10.0.8.

- `dotnet tool restore` — passed.
- `dotnet restore Bluent.sln` — canceled after prolonged NuGet network inactivity; no successful restore claim.
- `dotnet build Bluent.sln --configuration Release --no-restore -warnaserror` — passed, 0 warnings / 0 errors using previously restored assets.
- `dotnet test Bluent.sln --configuration Release --no-build` — passed, 19/19.
- `python3 -m unittest -v scripts/release/test_release_tools.py` — passed, 6/6, including trusted and rejected README image sources.
- Exactly five `1.0.367-validation.2` packages packed from commit `927dd201638ba812c021ee42748fad61dd87ad3d` — passed.
- Package validator — passed IDs, aligned versions, metadata, README, trusted README image sources, license, `net10.0`, static assets, repository commit, and exact internal dependencies.
- Deterministic dry-run notes from `Unreleased` — passed.
- Clean Blazor WebAssembly consumer with UI, Charts, Diagrams, and Utilities directly referenced and Core transitively resolved — restore and zero-warning Release build passed.
- Markdown links — passed across 34 maintained files.
- Workflow YAML — all three files parsed.
- Focused rendered accessibility smoke — passed four compatibility routes; this is not a WCAG conformance claim.
- `git diff --check origin/Dev` — passed.
- Official NuGet V2 endpoints returned HTTP 404 for candidate `1.0.367` across all five package IDs.

The first clean-consumer attempt used the macOS `/tmp` symlink and failed to resolve the template's own Razor `Layout` namespace. A package-free control failed identically. Both control and Bluent consumers passed when repeated through canonical `/private/tmp`; this is recorded rather than hidden.

## GitHub validation

Final head `c082ff6059d4c4ac1f8aa9cf486e93467048f48e`:

- [Quality run #30189535139](https://github.com/vrassouli/Bluent/actions/runs/30189535139) — passed build, 19/19 solution tests, 6/6 release-tool tests, five-package validation, links, workflow YAML, whitespace, and focused accessibility smoke.
- [Release packages run #30189535175](https://github.com/vrassouli/Bluent/actions/runs/30189535175) — artifact validation passed; NuGet publication and GitHub Release jobs were skipped.
- Downloaded artifact `bluent-0.0.0-ci.379` — inspected; contains exactly five aligned packages, `release/package-validation.json`, and deterministic `release/release-notes.md`.
- The report records aligned `0.0.0-ci.379` dependencies and pull-request merge ref commit `cda656e6275147015af50c8ea62e3c1c557dac21`; every nuspec uses the same commit.
- Every archived README was inspected directly and contains only the four trusted `img.shields.io` badges and the trusted, commit-pinned `raw.githubusercontent.com` screenshot.

## Maintainer prerequisites

Public GitHub metadata exposes only `github-pages` and cannot reveal secret presence.

- [ ] Approve or replace exact version `1.0.367`.
- [ ] Create and protect `nuget-production`.
- [ ] Add a scoped `NUGET_API_KEY` environment secret.
- [ ] Review and approve the final dated changelog section.
- [ ] Review the five dry-run packages, report, and deterministic notes.
- [ ] Explicitly authorize creation of the matching annotated tag.
- [ ] Explicitly authorize the production workflow run.

## Safety statement

**No NuGet package was published. No Git tag was created or pushed. No GitHub Release was created.**

This PR targets `Dev`, remains open for review, and must not be merged without maintainer authorization.