### PR TITLE
Finalize stable release 1.0.367

### DIFF
--- a/.bluent/BACKLOG.md
+++ b/.bluent/BACKLOG.md
@@ -6,17 +6,13 @@ Use `.bluent/PROJECT.md` for current status and `.bluent/HANDOFF.md` for the imm
 
 ## Now
 
-Stable release preparation tracked by
-[Issue #379](https://github.com/vrassouli/Bluent/issues/379):
+Final stable release candidate work tracked by
+[Issue #381](https://github.com/vrassouli/Bluent/issues/381):
 
-- Audit current published package versions and release prerequisites.
-- Propose an exact stable version without selecting it silently.
-- Reconcile the changelog with the already-published `1.0.366` packages.
-- Correct packaged README image sources for NuGet.org and prevent unsupported
-  sources from passing release validation.
-- Validate the five aligned packages and deterministic notes without
-  publication.
-- Open a preparation pull request for maintainer review.
+- Finalize the approved stable `1.0.367` changelog section dated 2026-07-26.
+- Validate the five existing published package IDs at exact version `1.0.367`.
+- Run and inspect the protected artifact-only workflow without publication.
+- Open the final release pull request targeting `Dev` for maintainer review.
 
 Do not publish packages or create a tag or GitHub Release as part of this work.
 

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -4,19 +4,22 @@ This file is the operational entry point for continuing Bluent with Codex or ano
 
 ## Current Objective
 
-Prepare the first stable release through the protected Sprint 3 workflow,
-tracked in [Issue #379](https://github.com/vrassouli/Bluent/issues/379).
+Finalize the approved stable `1.0.367` release candidate through the protected
+artifact-only workflow, tracked in
+[Issue #381](https://github.com/vrassouli/Bluent/issues/381).
 
 The preparation must not publish packages or create a tag or GitHub Release.
 
 ## Current Branch and Tracking
 
 - Base branch: `Dev`
-- Active branch: `release/stable-release-preparation`
-- Release-preparation issue:
-  [#379](https://github.com/vrassouli/Bluent/issues/379)
+- Active branch: `release/1.0.367`
+- Release issue: [#381](https://github.com/vrassouli/Bluent/issues/381)
+- Final release pull request: pending
+- Preparation issue:
+  [#379](https://github.com/vrassouli/Bluent/issues/379) — completed
 - Preparation pull request:
-  [#380](https://github.com/vrassouli/Bluent/pull/380) — draft
+  [#380](https://github.com/vrassouli/Bluent/pull/380) — merged
 - Sprint 3 plan: `.bluent/sprints/sprint-03.md`
 - Sprint issue: [#372](https://github.com/vrassouli/Bluent/issues/372) — completed
 - Sprint completion: [PR #377](https://github.com/vrassouli/Bluent/pull/377) — merged
@@ -57,19 +60,24 @@ Merged through PR #377:
 
 No real tag, GitHub Release, or NuGet publication was created during Sprint 3.
 
-## Current Release-Preparation State
+## Current Release State
 
-- PRs #377 and #378 are merged and there were no open pull requests when the
-  preparation branch was created from `Dev` commit `23bf85e`.
+- PR #380 is merged into `Dev`; `release/1.0.367` was created from merge commit
+  `f1cb349`.
 - All five packages have a newer published version than the Sprint 3 audit
   recorded: legacy `master`-push run #366 published aligned `1.0.366` packages
   on 2026-07-25 before the replacement workflow merged.
 - `1.0.366` is immutable and cannot be reused.
-- The evidence-based recommendation is stable `1.0.367`, pending explicit
-  maintainer approval.
+- The maintainer approved stable version `1.0.367` with release date
+  2026-07-26.
+- The five existing published package IDs remain `Bluent.UI.Core`, `Bluent.UI`,
+  `Bluent.UI.Charts`, `Bluent.UI.Diagrams`, and `Bluent.UI.Utilities`.
+- References to `Bluent.Core` as a NuGet package ID in Issue #381 are typos;
+  there is no package rename in this release.
 - No consumer migration is required by the audited post-`1.0.366` changes.
-- The required `nuget-production` environment is not visible in public GitHub
-  metadata. Secret presence cannot be verified through public metadata.
+- The maintainer confirmed that `nuget-production` exists and its
+  `NUGET_API_KEY` environment secret is configured. The secret value must not
+  be inspected.
 - The detailed evidence and remaining checks are in
   `docs/releasing/stable-release-readiness.md`.
 - The packaged README now uses a NuGet.org-trusted, commit-pinned screenshot
@@ -83,14 +91,12 @@ No real tag, GitHub Release, or NuGet publication was created during Sprint 3.
 
 Before any production publication, the maintainer still must:
 
-1. approve or replace the proposed exact version;
-2. review and finalize the matching `CHANGELOG.md` section;
-3. create and protect the `nuget-production` GitHub environment;
-4. add `NUGET_API_KEY` to that environment;
-5. create the exact matching `v<version>` tag only after review;
-6. explicitly authorize the production workflow run.
-
-Do not infer or invent a release version.
+1. review and merge the final release pull request;
+2. explicitly authorize an annotated `v1.0.367` tag on the exact merged release
+   commit;
+3. explicitly authorize the production workflow run from that tag with version
+   `1.0.367` and `publish: true`;
+4. approve the protected `nuget-production` deployment when prompted.
 
 ## Deferred Work
 
@@ -109,9 +115,8 @@ Do not infer or invent a release version.
 
 ## Next Session
 
-1. Review the updated PR #380 workflow evidence for packaged README validation.
-2. Approve or replace the proposed exact version `1.0.367`.
-3. Confirm the protected `nuget-production` environment and scoped
-   `NUGET_API_KEY`.
-4. Leave the pull request open until the maintainer's version and prerequisite
-   decisions.
+1. Complete local validation of the exact `1.0.367` candidate.
+2. Run `Release packages` with `publish: false` from the exact candidate commit.
+3. Inspect and record the `bluent-1.0.367` artifact.
+4. Open the final release pull request targeting `Dev` and leave it open for
+   maintainer review.

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -235,10 +235,10 @@ Release.
 
 ### Remaining work
 
-- [ ] Complete and record local build, test, exact pack, notes, documentation,
+- [x] Complete and record local build, test, exact pack, notes, documentation,
   workflow-YAML, and whitespace validation.
-- [ ] Validate a clean consumer against the five exact `1.0.367` packages.
-- [ ] Confirm all five `1.0.367` package ID/version pairs are absent on NuGet.
+- [x] Validate a clean consumer against the five exact `1.0.367` packages.
+- [x] Confirm all five `1.0.367` package ID/version pairs are absent on NuGet.
 - [ ] Record clean Quality and exact `publish: false` Release packages runs.
 - [ ] Inspect the uploaded `bluent-1.0.367` artifact.
 - [ ] Open the final non-draft release pull request targeting `Dev`.

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -9,9 +9,9 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 **Phase:** Stable Release Preparation
 **Current Sprint:** None; Sprint 3 is complete
 **Status:** In progress
-**Working Branch:** `release/stable-release-preparation`
-**Pull Request:** [#380](https://github.com/vrassouli/Bluent/pull/380) — draft
-**Tracking Issue:** [#379](https://github.com/vrassouli/Bluent/issues/379)
+**Working Branch:** `release/1.0.367`
+**Pull Request:** Pending
+**Tracking Issue:** [#381](https://github.com/vrassouli/Bluent/issues/381)
 
 ## Operational Files
 
@@ -21,7 +21,7 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 - `.bluent/BACKLOG.md` — current, next, later, and deferred project work.
 - `docs/releasing/release-workflow-audit.md` — Sprint 3 release audit.
 - `docs/releasing/stable-release-readiness.md` — current package evidence,
-  version recommendation, risks, prerequisites, and validation status.
+  approved version, risks, prerequisites, and validation status.
 - `docs/quality/compiler-warning-baseline.md` — zero-warning baseline and triage record.
 - `docs/compatibility/hosting-and-render-modes.md` — evidence-backed compatibility status.
 
@@ -191,37 +191,39 @@ Before a real NuGet release:
 
 Known deferred compatibility work remains tracked in Issue #366, including transient Interactive Server reconnection and exact Interactive Auto renderer-transition instrumentation.
 
-## Stable Release Preparation
+## Stable Release 1.0.367
 
-**Tracking:** [Issue #379](https://github.com/vrassouli/Bluent/issues/379)
+**Tracking:** [Issue #381](https://github.com/vrassouli/Bluent/issues/381)
 
-**Branch:** `release/stable-release-preparation`
+**Branch:** `release/1.0.367`
 
-**Pull Request:** [#380](https://github.com/vrassouli/Bluent/pull/380) — draft
+**Preparation:** [Issue #379](https://github.com/vrassouli/Bluent/issues/379)
+and [PR #380](https://github.com/vrassouli/Bluent/pull/380) — completed
 
 **Status:** In progress
 
-The maintainer selected a stable release through the protected workflow.
-Preparation is underway without publishing packages or creating a release tag
-or GitHub Release.
+The maintainer approved stable version `1.0.367` dated 2026-07-26 and confirmed
+that the protected `nuget-production` environment and its `NUGET_API_KEY`
+secret are configured. The secret value is not inspected. Final validation is
+underway without publishing packages or creating a release tag or GitHub
+Release.
 
 ### Current findings
 
-- PRs #377 and #378 are merged, and no pull requests were open when
-  preparation started from `Dev` commit `23bf85e`.
+- PR #380 is merged, and the final release branch starts from `Dev` merge
+  commit `f1cb349`.
 - The five-package publication set remains `Bluent.UI.Core`, `Bluent.UI`,
   `Bluent.UI.Charts`, `Bluent.UI.Diagrams`, and `Bluent.UI.Utilities`.
+- `Bluent.Core` references in Issue #381 are package-ID typos. No package
+  rename, dependency-boundary change, or migration is included in `1.0.367`.
 - Legacy `master`-push workflow run #366 published aligned stable `1.0.366`
   packages on 2026-07-25 before the protected workflow merged.
-- The recommended successor is stable `1.0.367`, pending explicit maintainer
-  approval. A patch is SemVer-correct because no incompatible public API,
-  behavior, package-boundary, target-framework, or static-asset change was
-  identified.
+- Stable `1.0.367` is the approved successor. A patch is SemVer-correct because
+  no incompatible public API, behavior, package-boundary, target-framework, or
+  static-asset change was identified.
 - No version-specific consumer migration is required.
-- Public GitHub metadata exposes only `github-pages`; it cannot verify
-  `nuget-production` or the presence of `NUGET_API_KEY`.
-- The changelog now separates changes already shipped in `1.0.366` from the
-  proposed `1.0.367` contents.
+- The changelog contains a dated `1.0.367` section and a fresh empty,
+  category-complete `Unreleased` section.
 - The packaged README now uses a NuGet.org-trusted, commit-pinned screenshot
   URL, and release validation rejects relative or untrusted image sources in
   each of the five packages.
@@ -233,17 +235,16 @@ or GitHub Release.
 
 ### Remaining work
 
-- [x] Complete and record local build, test, pack, notes, documentation,
-  workflow-YAML, whitespace, and focused accessibility validation.
-- [x] Validate a clean consumer against the five non-publish packages.
-- [x] Open the preparation pull request targeting `Dev`.
-- [x] Record clean Quality and Release packages artifact-only workflow runs.
-- [x] Correct and validate NuGet.org-compatible packaged README image sources.
-- [ ] Obtain the maintainer's exact-version decision.
-- [ ] Obtain maintainer confirmation of the protected environment and secret
-  prerequisites before any later publication authorization.
+- [ ] Complete and record local build, test, exact pack, notes, documentation,
+  workflow-YAML, and whitespace validation.
+- [ ] Validate a clean consumer against the five exact `1.0.367` packages.
+- [ ] Confirm all five `1.0.367` package ID/version pairs are absent on NuGet.
+- [ ] Record clean Quality and exact `publish: false` Release packages runs.
+- [ ] Inspect the uploaded `bluent-1.0.367` artifact.
+- [ ] Open the final non-draft release pull request targeting `Dev`.
 
-Community outreach, new product features, and Sprint 4 remain unstarted until this release decision is made.
+Community outreach, new product features, and Sprint 4 remain unstarted until
+the final release pull request is reviewed.
 
 ## Accepted Decisions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ versions aligned.
 
 - Corrected the packaged README screenshot URL for NuGet.org and added release
   validation that rejects relative or untrusted README image sources.
+- Kept pull-request artifact dry runs deterministic after release finalization
+  by using the latest dated release notes when `Unreleased` is empty.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,35 @@ Entries should identify affected packages when a change is not ecosystem-wide,
 for example `[Bluent.UI.Charts]`. Breaking changes must start with
 `**Breaking:**` and link to migration guidance.
 
-> Proposed stable version: `1.0.367` (pending maintainer approval). The
-> versioned section and release date will be created only after approval.
+### Added
+
+- None.
+
+### Changed
+
+- None.
+
+### Deprecated
+
+- None.
+
+### Removed
+
+- None.
+
+### Fixed
+
+- None.
+
+### Security
+
+- None.
+
+## [1.0.367] - 2026-07-26
+
+No version-specific consumer migration is required. Applications should
+continue to update directly installed Bluent packages together to keep their
+versions aligned.
 
 ### Added
 
@@ -96,3 +123,6 @@ history remains available on NuGet, but the repository has no historical tags
 or GitHub Releases from which complete release notes can be reconstructed.
 
 Future releases will add a dated section here and move the relevant entries from `Unreleased`.
+
+[Unreleased]: https://github.com/vrassouli/Bluent/compare/v1.0.367...Dev
+[1.0.367]: https://github.com/vrassouli/Bluent/compare/9056d1c5b3b9f0d714854da0a1712efa55fd3ed8...v1.0.367

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,7 +70,9 @@ When releasing:
 The release workflow extracts notes from the exact
 `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD` section. A publication run fails if that
 section is missing or empty. Artifact-only dry runs may preview notes from
-`Unreleased`, but that preview cannot be used for a real GitHub Release.
+`Unreleased`. When a finalized release leaves `Unreleased` empty, pull-request
+dry runs use the latest non-empty dated release section instead. Neither
+preview can be used for a real GitHub Release.
 
 ## Automated release workflow
 

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -268,7 +268,10 @@ runtime 10.0.8.
 | Release build with `--no-restore -warnaserror` | Passed with 0 warnings and 0 errors |
 | Full solution tests | Passed 19/19 |
 | Release-tool tests | Passed 6/6 |
+| Exact five-package pack | Passed at `1.0.367` |
+| Package validation | Passed IDs, aligned versions, exact internal dependencies, repository commit, license, `net10.0`, README, trusted README image sources, and expected static assets |
 | Deterministic notes | Passed from the dated `1.0.367` section |
+| Clean Blazor WebAssembly consumer | Passed restore and zero-warning Release build with `Bluent.UI`, Charts, Diagrams, and Utilities directly referenced; `Bluent.UI.Core` resolved transitively |
 | Markdown links | Passed across 34 maintained files |
 | Workflow YAML | All three workflow files parsed |
 | Focused rendered accessibility | Passed four compatibility routes; not a WCAG conformance claim |

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -2,22 +2,28 @@
 
 **Audit date:** 2026-07-26
 
-**Audited branch:** `release/stable-release-preparation`
+**Release branch:** `release/1.0.367`
 
-**Base commit:** `23bf85e35ae85532603812f758a74916eb03fe4d`
+**Base commit:** `f1cb349`
 
-**Tracking:** [Issue #379](https://github.com/vrassouli/Bluent/issues/379)
+**Tracking:** [Issue #381](https://github.com/vrassouli/Bluent/issues/381)
 
-**Preparation PR:** [#380](https://github.com/vrassouli/Bluent/pull/380)
+**Preparation:** [Issue #379](https://github.com/vrassouli/Bluent/issues/379)
+and [PR #380](https://github.com/vrassouli/Bluent/pull/380) — completed
 
 ## Decision status
 
-The maintainer selected a stable release through the protected Sprint 3
-workflow. The exact version remains pending maintainer approval.
+The maintainer approved a stable release through the protected Sprint 3
+workflow.
 
-**Recommendation:** `1.0.367`
+**Approved version and date:** `1.0.367` — 2026-07-26
 
-No package, tag, or GitHub Release is created by this preparation work.
+The existing five-package set is unchanged. `Bluent.Core` references in Issue
+#381 are package-ID typos; the published Core package remains
+`Bluent.UI.Core`. No package rename or migration change is part of this
+release.
+
+No package, tag, or GitHub Release is created by this finalization work.
 
 ## Repository reconciliation
 
@@ -25,18 +31,18 @@ No package, tag, or GitHub Release is created by this preparation work.
   2026-07-25.
 - PR [#378](https://github.com/vrassouli/Bluent/pull/378) merged into `Dev` on
   2026-07-25.
-- The GitHub pull-request API returned no open pull requests at audit time.
-- `Dev` resolved to `23bf85e35ae85532603812f758a74916eb03fe4d`
-  before this branch was created.
+- PR [#380](https://github.com/vrassouli/Bluent/pull/380) merged into `Dev` on
+  2026-07-26.
+- `Dev` resolved to merge commit `f1cb349` before the final release branch was
+  created.
 - The publication set remains exactly five packages:
   `Bluent.UI.Core`, `Bluent.UI`, `Bluent.UI.Charts`,
   `Bluent.UI.Diagrams`, and `Bluent.UI.Utilities`.
 
 ## Published package evidence
 
-NuGet's official V2 package endpoints were queried for each exact package and
-version. The V3 flat-container requests timed out during TLS negotiation in the
-local environment, so the successful V2 results are the recorded evidence.
+NuGet's official V3 flat-container endpoints were queried for each exact
+package and version.
 
 | Package | Latest verified version | Published (UTC) | Direct Bluent dependency |
 | --- | --- | --- | --- |
@@ -62,11 +68,11 @@ Consequences:
 - Its already-shipped changes are now recorded in the dated `1.0.366`
   changelog section instead of being attributed to the next release.
 
-## Version recommendation
+## Approved version
 
-### Proposed exact version
+### Exact version
 
-`1.0.367`, pending explicit maintainer approval.
+`1.0.367`, approved by the maintainer for 2026-07-26.
 
 ### SemVer justification
 
@@ -99,15 +105,13 @@ container, and asset paths remain unchanged.
 
 ### Risks
 
-- This would be the first production use of the replacement workflow.
-- The required `nuget-production` environment is not visible through public
-  GitHub metadata.
-- The presence or value of `NUGET_API_KEY` cannot be verified through public
-  GitHub metadata and must remain a maintainer-owned prerequisite.
+- This will be the first production use of the replacement workflow.
+- The maintainer reports that the protected `nuget-production` environment
+  exists and its `NUGET_API_KEY` secret is configured. The secret value is not
+  inspected; the protected production workflow will prove the configuration
+  only after separate publication authorization.
 - NuGet cannot publish five packages atomically. Preflight and dependency-order
   publication reduce, but cannot eliminate, partial-publication risk.
-- The dated `1.0.367` changelog section must not be created until the
-  maintainer approves the version and release date.
 - The already-published `1.0.366` package README cannot be edited in place, so
   its unsupported-image warning remains until a corrected version is
   published.
@@ -153,13 +157,14 @@ after a corrected new version is published.
 The previous `Unreleased` section mixed changes already shipped in `1.0.366`
 with post-`1.0.366` work. It was not suitable as `1.0.367` release notes.
 
-This preparation:
+The preparation and finalization work:
 
 - moves the already-shipped entries into a dated `1.0.366` section;
 - records the absence of a corresponding tag and GitHub Release;
-- keeps post-`1.0.366` release, quality, and compatibility work under
-  `Unreleased`;
-- marks `1.0.367` as a proposal pending approval.
+- moves the approved post-`1.0.366` release, quality, and compatibility work
+  into the dated `1.0.367` section;
+- creates a fresh empty, category-complete `Unreleased` section;
+- records that no version-specific consumer migration is required.
 
 No breaking entry or version-specific migration guide is required.
 
@@ -180,20 +185,19 @@ workflow:
 - publishes through `nuget-production`;
 - creates a GitHub Release only after NuGet publication.
 
-Public GitHub metadata currently exposes only the `github-pages` environment.
-It exposes no repository tags or GitHub Releases. Public metadata cannot reveal
-whether a secret exists. The maintainer must therefore confirm all of the
-following before any production action:
+The maintainer confirmed that `nuget-production` exists and the scoped
+`NUGET_API_KEY` environment secret is configured. Secret contents were not
+inspected. Before any production action, the maintainer still must:
 
-- [ ] Approve or replace the proposed exact version `1.0.367`.
-- [ ] Create and protect `nuget-production`.
-- [ ] Add the scoped `NUGET_API_KEY` environment secret.
-- [ ] Review the final dated changelog section.
-- [ ] Review the five dry-run packages and validation report.
-- [ ] Authorize creation of the matching annotated tag.
-- [ ] Authorize the production workflow run.
+- [ ] Review and merge the final release pull request.
+- [ ] Review the five exact dry-run packages, validation report, and notes.
+- [ ] Authorize the matching annotated `v1.0.367` tag on the exact merged
+  release commit.
+- [ ] Authorize the production workflow run from that tag with version
+  `1.0.367` and `publish: true`.
+- [ ] Approve the protected `nuget-production` deployment when prompted.
 
-## Validation record
+## Preparation validation record
 
 Local environment: macOS 26.5, Apple Silicon, .NET SDK 10.0.300, and .NET
 runtime 10.0.8.
@@ -228,7 +232,7 @@ four `img.shields.io` badges and the commit-pinned `raw.githubusercontent.com`
 screenshot, with no relative or unsupported image source. No package was
 pushed to NuGet.
 
-## GitHub Actions evidence
+## Preparation GitHub Actions evidence
 
 PR #380 head `927dd201638ba812c021ee42748fad61dd87ad3d` produced:
 
@@ -248,6 +252,30 @@ and the same five trusted README image sources for every package. Each package
 nuspec contains that same repository commit. Direct inspection of all five
 archived README files passed the trusted-source validator. The notes are a
 deterministic `Unreleased` preview with the required dry-run warning and the
-pending `1.0.367` recommendation.
+then-proposed `1.0.367` recommendation.
 
 No publication job ran, and no external release state changed.
+
+## Final `1.0.367` validation
+
+Local environment: macOS 26.5, Apple Silicon, .NET SDK 10.0.300, and .NET
+runtime 10.0.8.
+
+| Check | Result |
+| --- | --- |
+| `dotnet tool restore` | Passed |
+| `dotnet restore Bluent.sln` | Passed |
+| Release build with `--no-restore -warnaserror` | Passed with 0 warnings and 0 errors |
+| Full solution tests | Passed 19/19 |
+| Release-tool tests | Passed 6/6 |
+| Deterministic notes | Passed from the dated `1.0.367` section |
+| Markdown links | Passed across 34 maintained files |
+| Workflow YAML | All three workflow files parsed |
+| Focused rendered accessibility | Passed four compatibility routes; not a WCAG conformance claim |
+| Whitespace | `git diff --check origin/Dev` passed |
+| Candidate availability | Official NuGet V3 flat-container preflight confirmed `1.0.367` is unused for all five package IDs |
+
+Exact package metadata, dependency, README, clean-consumer, repository-commit,
+Quality workflow, artifact-only Release workflow, and downloaded-artifact
+evidence is recorded in the final release pull request so recording the
+evidence does not mutate the exact validated candidate afterward.

--- a/docs/releasing/stable-release-readiness.md
+++ b/docs/releasing/stable-release-readiness.md
@@ -267,7 +267,7 @@ runtime 10.0.8.
 | `dotnet restore Bluent.sln` | Passed |
 | Release build with `--no-restore -warnaserror` | Passed with 0 warnings and 0 errors |
 | Full solution tests | Passed 19/19 |
-| Release-tool tests | Passed 6/6 |
+| Release-tool tests | Passed 7/7 |
 | Exact five-package pack | Passed at `1.0.367` |
 | Package validation | Passed IDs, aligned versions, exact internal dependencies, repository commit, license, `net10.0`, README, trusted README image sources, and expected static assets |
 | Deterministic notes | Passed from the dated `1.0.367` section |
@@ -282,3 +282,9 @@ Exact package metadata, dependency, README, clean-consumer, repository-commit,
 Quality workflow, artifact-only Release workflow, and downloaded-artifact
 evidence is recorded in the final release pull request so recording the
 evidence does not mutate the exact validated candidate afterward.
+
+The final pull request exposed and corrected one additional dry-run edge case:
+after release finalization creates an empty `Unreleased` section, synthetic
+pull-request package versions now use the latest non-empty dated release
+section for deterministic preview notes. Exact-version artifact and publication
+runs still require their matching dated changelog section.

--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,7 @@ Bluent is open source under Apache License 2.0. The current repository targets .
 - [Release policy](https://github.com/vrassouli/Bluent/blob/Dev/RELEASING.md): Semantic Versioning, validation, tagging, and publication
 - [Changelog](https://github.com/vrassouli/Bluent/blob/Dev/CHANGELOG.md): notable changes and release history
 - [Release workflow audit](https://github.com/vrassouli/Bluent/blob/Dev/docs/releasing/release-workflow-audit.md): audited version sources, publication history, workflow risks, and required controls
-- [Stable release readiness](https://github.com/vrassouli/Bluent/blob/Dev/docs/releasing/stable-release-readiness.md): current package evidence, proposed version, migration impact, risks, and maintainer prerequisites
+- [Stable release readiness](https://github.com/vrassouli/Bluent/blob/Dev/docs/releasing/stable-release-readiness.md): approved release version, package evidence, migration impact, validation, risks, and maintainer prerequisites
 - [Compiler warning baseline](https://github.com/vrassouli/Bluent/blob/Dev/docs/quality/compiler-warning-baseline.md): warning inventory, dispositions, and zero-warning regression policy
 - [Coding-agent instructions](https://github.com/vrassouli/Bluent/blob/Dev/AGENTS.md): repository facts, guardrails, build commands, and documentation rules
 

--- a/scripts/release/release_tools.py
+++ b/scripts/release/release_tools.py
@@ -131,6 +131,29 @@ def changelog_section(text: str, heading: str) -> str | None:
     return match.group(0).strip() + "\n"
 
 
+def meaningful_changelog_entries(section: str) -> list[str]:
+    return [
+        line
+        for line in section.splitlines()
+        if line.startswith("- ") and line != "- None."
+    ]
+
+
+def latest_dated_release(text: str) -> tuple[str, str] | None:
+    for match in re.finditer(
+        r"^## \[(?P<version>[^\]]+)\] - \d{4}-\d{2}-\d{2}\s*$",
+        text,
+        re.MULTILINE,
+    ):
+        version = match.group("version")
+        if not SEMVER_PATTERN.fullmatch(version):
+            continue
+        section = changelog_section(text, version)
+        if section is not None and meaningful_changelog_entries(section):
+            return version, section
+    return None
+
+
 def extract_notes(args: argparse.Namespace) -> None:
     validate_version(args.version)
     text = args.changelog.read_text(encoding="utf-8-sig")
@@ -139,6 +162,10 @@ def extract_notes(args: argparse.Namespace) -> None:
     if section is None and args.allow_unreleased:
         section = changelog_section(text, "Unreleased")
         source = "Unreleased"
+        if section is None or not meaningful_changelog_entries(section):
+            latest = latest_dated_release(text)
+            if latest is not None:
+                source, section = latest
     if section is None:
         fail(
             f"CHANGELOG.md has no section for [{args.version}]. A publish run "
@@ -150,21 +177,25 @@ def extract_notes(args: argparse.Namespace) -> None:
         re.MULTILINE,
     ):
         fail(f"The [{source}] changelog section has no recognized change category.")
-    meaningful = [
-        line
-        for line in section.splitlines()
-        if line.startswith("- ") and line != "- None."
-    ]
+    meaningful = meaningful_changelog_entries(section)
     if not meaningful:
         fail(f"The [{source}] changelog section contains no release-note entries.")
-    output = (
-        f"# Bluent {args.version}\n\n"
-        + (
+    if source == "Unreleased":
+        dry_run_notice = (
             "> Dry-run preview generated from the Unreleased section. A real "
             "publication requires a dated version section.\n\n"
-            if source == "Unreleased"
-            else ""
         )
+    elif source != args.version:
+        dry_run_notice = (
+            f"> Dry-run preview generated from [{source}] because the "
+            "Unreleased section contains no entries. A real publication "
+            "requires the exact requested version section.\n\n"
+        )
+    else:
+        dry_run_notice = ""
+    output = (
+        f"# Bluent {args.version}\n\n"
+        + dry_run_notice
         + "\n".join(section.splitlines()[1:]).strip()
         + "\n"
     )

--- a/scripts/release/test_release_tools.py
+++ b/scripts/release/test_release_tools.py
@@ -56,6 +56,38 @@ Historical prose.
                     )
                 )
 
+    def test_dry_run_uses_latest_release_when_unreleased_is_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            changelog = root / "CHANGELOG.md"
+            output = root / "notes.md"
+            changelog.write_text(
+                """## [Unreleased]
+
+### Added
+
+- None.
+
+## [1.2.3] - 2026-07-26
+
+### Fixed
+
+- A released fix.
+""",
+                encoding="utf-8",
+            )
+            release_tools.extract_notes(
+                Namespace(
+                    changelog=changelog,
+                    version="0.0.0-ci.1",
+                    output=output,
+                    allow_unreleased=True,
+                )
+            )
+            notes = output.read_text(encoding="utf-8")
+            self.assertIn("generated from [1.2.3]", notes)
+            self.assertIn("- A released fix.", notes)
+
     def test_accepts_nuget_trusted_readme_image_sources(self) -> None:
         readme = """\
 ![NuGet](https://img.shields.io/nuget/v/Bluent.UI.svg)


### PR DESCRIPTION
## Outcome

Finalizes the approved stable Bluent **1.0.367** release candidate dated **2026-07-26** without publishing packages, creating a tag, or creating a GitHub Release.

Closes #381

## Package identity

The existing five published package IDs are preserved exactly:

- `Bluent.UI.Core`
- `Bluent.UI`
- `Bluent.UI.Charts`
- `Bluent.UI.Diagrams`
- `Bluent.UI.Utilities`

References to `Bluent.Core` as a package ID in Issue #381 were treated as typos. This PR does not rename a package, change package boundaries, or require version-specific migration.

## Changes

- Finalizes `CHANGELOG.md` as `## [1.0.367] - 2026-07-26`.
- Creates a fresh empty, category-complete `Unreleased` section.
- Adds changelog comparison links and records that no version-specific migration is required.
- Updates project, handoff, backlog, readiness, and machine-readable release status for the approved version.
- Fixes PR artifact-note generation after release finalization: when `Unreleased` is empty, a synthetic dry run deterministically previews the latest non-empty dated release; exact-version runs still require their matching dated section.
- Adds release-tool coverage for that finalized-changelog dry-run case.
- Records the maintainer-confirmed `nuget-production` environment and `NUGET_API_KEY` configuration without inspecting secret contents.

Exact files changed:

- `.bluent/BACKLOG.md`
- `.bluent/HANDOFF.md`
- `.bluent/PROJECT.md`
- `CHANGELOG.md`
- `RELEASING.md`
- `docs/releasing/stable-release-readiness.md`
- `llms.txt`
- `scripts/release/release_tools.py`
- `scripts/release/test_release_tools.py`

## Exact candidate

Final commit: `0fb72cd03113e956758a76e2f12b6b902a0e4d9d`

## Local validation

Environment: macOS 26.5, Apple Silicon, .NET SDK 10.0.300, runtime 10.0.8.

- `dotnet tool restore` — passed.
- `dotnet restore Bluent.sln` — passed.
- `dotnet build Bluent.sln --configuration Release --no-restore -warnaserror` — passed, 0 warnings / 0 errors.
- `dotnet test Bluent.sln --configuration Release --no-build` — passed, 19/19.
- `python3 -m unittest -v scripts/release/test_release_tools.py` — passed, 7/7.
- Exact pack of all five packages at `1.0.367` — passed on the final commit.
- Package validation — passed IDs, aligned versions, exact internal dependencies, repository commit, Apache-2.0 license, `net10.0`, README, trusted README image sources, and expected static assets.
- Deterministic exact `1.0.367` notes and synthetic finalized-changelog preview notes — passed.
- Clean standalone Blazor WebAssembly consumer — restore and zero-warning Release build passed with UI, Charts, Diagrams, and Utilities directly referenced and `Bluent.UI.Core` resolved transitively.
- `python3 scripts/quality/check_markdown_links.py` — passed across 34 maintained files.
- Workflow YAML parsing — all three workflow files passed.
- Focused rendered accessibility smoke — passed four compatibility routes; this is not a WCAG conformance claim.
- `git diff --check origin/Dev` — passed.
- Official NuGet V3 flat-container preflight — `1.0.367` is unused for all five package IDs.

## GitHub validation

Final commit `0fb72cd03113e956758a76e2f12b6b902a0e4d9d`:

- [PR Quality run #30190411445](https://github.com/vrassouli/Bluent/actions/runs/30190411445) — passed.
- [PR synthetic Release packages run #30190411453](https://github.com/vrassouli/Bluent/actions/runs/30190411453) — passed; publication jobs skipped.
- [Exact Release packages run #30190428552](https://github.com/vrassouli/Bluent/actions/runs/30190428552) — passed with `version: 1.0.367` and `publish: false`; publication jobs skipped.

An earlier PR synthetic Release-packages run [#30190333250](https://github.com/vrassouli/Bluent/actions/runs/30190333250) failed because its synthetic version fell back to the newly empty `Unreleased` section. This was not hidden: the release tool was corrected and covered by a new test, and final PR and exact-version runs both pass.

## Artifact inspection

Downloaded and inspected `bluent-1.0.367` from exact Release packages run #30190428552.

- Contains exactly five `.nupkg` files plus `release/package-validation.json` and `release/release-notes.md`.
- Every package is version `1.0.367` and records repository commit `0fb72cd03113e956758a76e2f12b6b902a0e4d9d`.
- Internal dependencies are exact and aligned: UI, Charts, and Diagrams depend on `Bluent.UI.Core 1.0.367`; Utilities depends on `Bluent.UI 1.0.367`.
- The uploaded validation JSON matched a fresh local revalidation.
- Every packaged README contains exactly the four expected `img.shields.io` sources and the trusted commit-pinned `raw.githubusercontent.com` screenshot.
- Uploaded release notes exactly match deterministic generation from the dated `1.0.367` changelog section.

## Protected configuration

The maintainer reported that `nuget-production` exists and its `NUGET_API_KEY` environment secret is configured. Secret contents were not exposed, inspected, copied, or tested.

## Remaining risk

This remains the first production use of the replacement workflow, and NuGet cannot publish five packages atomically. The workflow's preflight, dependency ordering, protected environment, and required maintainer approval reduce but cannot eliminate partial-publication risk.

GitHub emitted a Node.js 20 deprecation annotation for upstream `actions/*@v4` actions being forced onto Node.js 24; it did not fail validation and is not changed in this focused release PR.

## Safety statement

**No NuGet package was published. No Git tag was created or pushed. No GitHub Release was created.**

## Maintainer checklist

- [ ] Approve and merge this release PR.
- [ ] Authorize annotated tag `v1.0.367` on the exact merged release commit.
- [ ] Authorize the production workflow run from that tag with version `1.0.367` and `publish: true`.
- [ ] Approve the protected `nuget-production` deployment when prompted.
