### PR TITLE
Close small documentation and validator gaps

### DIFF
--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -191,6 +191,34 @@ Before a real NuGet release:
 
 Known deferred compatibility work remains tracked in Issue #366, including transient Interactive Server reconnection and exact Interactive Auto renderer-transition instrumentation.
 
+## Post-Sprint 3 Small Backlog Cleanup
+
+**Issues:** [#374](https://github.com/vrassouli/Bluent/issues/374),
+[#375](https://github.com/vrassouli/Bluent/issues/375), and
+[#376](https://github.com/vrassouli/Bluent/issues/376)
+
+**Branch:** `chore/close-small-open-issues`
+
+### Completed on branch
+
+- [x] Add source-verified canonical Badge and Checkbox references without
+  changing either component or its public API.
+- [x] Update the component index, coverage inventory, and `llms.txt` for both
+  references.
+- [x] Add temporary standard-library `.nupkg` fixtures covering a valid package
+  set and five focused package-validator failures.
+
+### Validation Summary
+
+- Release-tool tests passed 13/13, including all six synthetic package
+  scenarios.
+- Markdown links passed across 36 maintained files.
+- Solution restore passed.
+- Release build passed with warnings treated as errors: 0 warnings, 0 errors.
+- Application tests passed 19/19.
+- The diff against `origin/Dev` passed `git diff --check`.
+- No package, tag, GitHub Release, or product API was created or published.
+
 ## Stable Release 1.0.367
 
 **Tracking:** [Issue #381](https://github.com/vrassouli/Bluent/issues/381)

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -6,6 +6,8 @@ Bluent component documentation is developed from a source-derived inventory and 
 
 - [Public component inventory and coverage](inventory.md)
 - [Component reference template](TEMPLATE.md)
+- [Badge](badge.md)
+- [Checkbox](checkbox.md)
 - [Dialog](dialog.md)
 - [Getting Started](../getting-started/index.md)
 - [Package selection and boundaries](../packages/index.md)
@@ -14,6 +16,6 @@ Bluent component documentation is developed from a source-derived inventory and 
 
 ## Current status
 
-The Sprint 1 inventory tracks 71 initial component families or public types across the main UI, Charts, Diagrams, and Utilities packages. Canonical per-component references are now the next documentation stage.
+The Sprint 1 inventory tracks 71 initial component families or public types across the main UI, Charts, Diagrams, and Utilities packages. Canonical references currently cover Badge, Checkbox, and Dialog, with the inventory recording their distinct source, build, and runtime evidence.
 
 A demo page or source file does not count as completed documentation. A reference progresses from draft to source verified, then runtime verified, using the status definitions in the inventory.

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -1,0 +1,168 @@
+# Badge
+
+`Badge` displays a compact text or icon marker for a count, category, status, or notification.
+
+## When to use
+
+Use `Badge` when:
+
+- a short count or status needs to be visible beside other content;
+- a compact visual marker helps distinguish a category or severity;
+- a button or other control needs a small notification indicator.
+
+Use normal text or a `MessageBar` when the message needs explanation or action. Do not rely on color alone to communicate meaning.
+
+## Package and namespace
+
+```bash
+dotnet add package Bluent.UI
+```
+
+```razor
+@using Bluent.UI.Components
+```
+
+Follow [Getting Started](../getting-started/index.md) to call `AddBluentUI()` and include the packaged theme and component stylesheets. A basic Badge does not need an overlay container; inherited tooltip parameters use the tooltip service and `<Containers />`.
+
+## Minimal example
+
+```razor
+<Badge Text="3"
+       Color="BadgeColor.Informative"
+       Shape="BadgeShape.Rounded"
+       aria-label="3 unread notifications" />
+```
+
+The shared Badge demo compiles examples for every current appearance, size, shape, and color enum value. This minimal example is source verified; Badge-specific browser behavior was not exercised for this page.
+
+## Parameters
+
+| Parameter | Type | Default | Required | Description |
+| --- | --- | --- | --- | --- |
+| `Appearance` | `BadgeAppearance` | `BadgeAppearance.Filled` | No | Visual treatment. Values: `Filled`, `Ghost`, `Outlined`, `Tint`. |
+| `Size` | `BadgeSize` | `BadgeSize.Medium` | No | Badge dimensions. Values: `Tiny`, `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`. |
+| `Shape` | `BadgeShape` | `BadgeShape.Circular` | No | Border-radius treatment. Values: `Square`, `Rounded`, `Circular`. |
+| `Color` | `BadgeColor` | `BadgeColor.Brand` | No | Color treatment. Values: `Brand`, `Danger`, `Important`, `Informative`, `Sever`, `Subtle`, `Success`, `Warning`. `Sever` is the current public enum spelling. |
+| `Icon` | `string?` | `null` | No | Passed to an `Icon` component rendered before `Text`. The Icon component interprets the string as SVG markup, an image path, or a CSS class according to its existing rules. |
+| `Text` | `string?` | `null` | No | Text rendered inside the badge. Badge does not accept arbitrary child content. |
+| `DropShadow` | `bool` | `false` | No | Adds a color-derived drop shadow. |
+| `AnimateShadow` | `bool` | `false` | No | Pulses the shadow when `DropShadow` is also `true`. It has no effect by itself. |
+| `Tooltip` | `string?` | `null` | No | Inherited plain-text tooltip content. |
+| `TooltipContent` | `RenderFragment?` | `null` | No | Inherited rendered tooltip content; takes precedence over `Tooltip`. |
+| `TooltipPlacement` | `Placement` | `Placement.Top` | No | Inherited tooltip placement. |
+| `TooltipAppearance` | `PopoverAppearance` | `PopoverAppearance.Default` | No | Inherited tooltip appearance. |
+| `DisplayTooltipArrow` | `bool` | `false` | No | Shows an arrow on the inherited tooltip. |
+| `Class` | `string?` | `null` | No | Adds CSS classes to the badge root. |
+| `Style` | `string?` | `null` | No | Adds inline styles to the badge root. |
+| Unmatched attributes | `Dictionary<string, object>?` | `null` | No | Applied to the root `<div>`, including attributes such as `aria-label`, `role`, and `data-*`. |
+
+`BadgeColor.Sever` is implemented as a dark-orange severity treatment. Documentation preserves the actual public name and does not silently rename it.
+
+## Events and binding
+
+Badge exposes no component-specific event or bindable value. It is display-only.
+
+## Child content and composition
+
+Badge renders, in order:
+
+1. an `Icon` component when `Icon` is non-empty;
+2. a text container containing `Text`.
+
+There is no `ChildContent` parameter. Use `Text` and `Icon`; nested markup inside `<Badge>...</Badge>` is not a supported composition API. The current demo contains a nested Badge example in its button-integration section, but that markup is not backed by the component's public source and should not be copied.
+
+An empty Badge is supported by the render logic and produces the size/shape marker without text. `Tiny` and `ExtraSmall` are fixed dot-like sizes in the current stylesheet.
+
+## Services and containers
+
+Call `AddBluentUI()` because Badge inherits tooltip service injection from `BluentUiComponentBase`. A basic Badge does not add content to `<Containers />`.
+
+When `Tooltip` or `TooltipContent` is used, place one `<Containers />` in the active interactive layout so the inherited tooltip service has its tooltip container.
+
+## Styling and theming
+
+Include the standard theme and component bundles from [the theming and assets guide](../guides/theming-localization-rtl-and-assets.md).
+
+- `Appearance` selects filled, transparent ghost, outlined, or tinted styling.
+- `Color` selects a source-defined theme-token combination.
+- `Shape` selects square, rounded, or circular corners.
+- `Size` selects one of six dimensions; `Medium` uses the base 20-pixel style.
+- `DropShadow` and `AnimateShadow` add static or pulsing color-derived shadow styling.
+
+The styles use Bluent theme tokens and therefore follow the active token set. Color and appearance combinations share the current CSS cascade; not every combination has a separately defined color override. Use `Class` and `Style` for application-specific adjustments, and do not treat internal generated classes as a stable public contract.
+
+## Localization and RTL
+
+Badge has no built-in localized strings or culture-sensitive formatting. The application supplies `Text` and any accessible name.
+
+The root uses inline flex layout and inherits document direction. There is no Badge-specific RTL selector, and the combinations of icon, text, shape, and surrounding controls have not been visually verified in RTL.
+
+## Accessibility and keyboard interaction
+
+The source renders a non-focusable `<div>` with no default semantic role or live-region behavior. Visible `Text` is exposed as text content, but color, shape, an empty marker, or a CSS icon alone does not provide an accessible name or meaning.
+
+For meaningful status or notification badges, provide adjacent explanatory text or appropriate unmatched attributes such as `aria-label` and a role selected for the application's semantics. Do not assume count changes are announced automatically.
+
+Badge has no keyboard interaction. The pulsing shadow animation does not include a component-specific reduced-motion rule, so avoid `AnimateShadow` when motion would be inappropriate. Complete assistive-technology, color-contrast, reduced-motion, and RTL accessibility verification has not been recorded.
+
+## Hosting and render modes
+
+See [Hosting models and render modes](../compatibility/hosting-and-render-modes.md) for the repository-wide evidence and setup.
+
+| Render mode | Status | Notes |
+| --- | --- | --- |
+| Standalone WebAssembly | Unverified | The demo compiles, but Badge-specific runtime evidence was not recorded. |
+| Interactive Server | Unverified | The representative mode baseline passed, but Badge-specific behavior was not separately recorded. |
+| Interactive WebAssembly | Unverified | The representative mode baseline passed, but Badge-specific behavior was not separately recorded. |
+| Interactive Auto | Unverified | The representative mode baseline passed, but Badge-specific behavior was not separately recorded. |
+| Static SSR | Limited | Basic display markup does not require interaction; Badge-specific static output was not separately runtime verified. Tooltips require an interactive mode. |
+
+## JavaScript and static assets
+
+A basic Badge imports no component-specific JavaScript and requires no manual script tag. It requires:
+
+- `_content/Bluent.UI/bluent.ui.theme.default.min.css` or another packaged Bluent theme;
+- `_content/Bluent.UI/bluent.ui.components.min.css`.
+
+Inherited tooltips use the base package's tooltip service and dynamically imported module. The base component removes a registered tooltip during async disposal.
+
+## Common mistakes
+
+### Nested content does not render as Badge content
+
+Badge has no `ChildContent` parameter. Set `Text` and `Icon` instead.
+
+### The shadow does not animate
+
+Set both `DropShadow="true"` and `AnimateShadow="true"`. `AnimateShadow` only adds the animation class inside the `DropShadow` branch.
+
+### A status is conveyed only by color
+
+Add meaningful `Text`, nearby explanatory content, or an accessible name appropriate to the surrounding UI.
+
+## Known limitations
+
+- No child-content slot is exposed.
+- There is no default status role, live-region behavior, or accessible name for icon-only and empty badges.
+- The public color value is spelled `BadgeColor.Sever`; changing that name would be a public API change.
+- Animated shadows have no Badge-specific reduced-motion fallback.
+- Component-specific runtime, visual, color-contrast, assistive-technology, and RTL verification is not recorded.
+
+## Related components
+
+- `MessageBar`, `Icon`, and `Button` are listed in the [component inventory](inventory.md).
+- [Getting Started](../getting-started/index.md)
+- [Theming, localization, RTL, and browser assets](../guides/theming-localization-rtl-and-assets.md)
+
+## Source and verification
+
+- Component source: `src/Bluent.UI/Components/BadgeComponent/Badge.razor`
+- Component logic: `src/Bluent.UI/Components/BadgeComponent/Badge.razor.cs`
+- Public enums: `src/Bluent.UI/Components/BadgeComponent/`
+- Icon behavior: `src/Bluent.UI/Components/IconComponent/Icon.cs`
+- Styles: `src/Bluent.UI/Styles/Components/_badge.scss`
+- Compiled demo: `src/Bluent.UI.Demo.Pages/Pages/Components/Badges.razor`
+- Source verified against `Dev` commit `07e61ed8552176c1719ec94c81ea3fda867bae9e`
+- Verification date: 2026-07-26
+
+The API, enum values, render order, styling rules, and example are source verified. The example participates in the solution build; no new browser, visual, keyboard, or assistive-technology verification was performed for this page.

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -1,0 +1,179 @@
+# Checkbox
+
+`Checkbox<TValue>` lets a user switch a Boolean value between checked and unchecked states and can display a programmatically supplied nullable value as indeterminate.
+
+## When to use
+
+Use `Checkbox` when:
+
+- a form needs one independent Boolean choice;
+- a user can select multiple independent options from a set;
+- an application needs to display a `bool?` value whose current state may be unknown.
+
+Use `RadioGroup` when exactly one option must be selected from a mutually exclusive set. Use `Switch` when the choice represents an immediately applied on/off setting rather than form selection.
+
+## Package and namespace
+
+```bash
+dotnet add package Bluent.UI
+```
+
+```razor
+@using Bluent.UI.Components
+```
+
+Follow [Getting Started](../getting-started/index.md) to call `AddBluentUI()` and include the packaged theme and component stylesheets. `Checkbox` does not use an overlay container.
+
+## Minimal example
+
+```razor
+<Checkbox @bind-Value="_sendUpdates"
+          Label="Send product and maintenance updates" />
+
+<p>Updates: @(_sendUpdates ? "enabled" : "disabled")</p>
+
+@code {
+    private bool _sendUpdates;
+}
+```
+
+This binding form is compiled in the shared Checkbox demo and in the customer-profile scenario. The repository's standalone WebAssembly compatibility evidence also exercised Checkbox binding; the component-specific behavior has not been rerun in every render mode.
+
+## Parameters
+
+`TValue` must be `bool` or `bool?`. Constructing the component with another type throws `InvalidOperationException`.
+
+| Parameter | Type | Default | Required | Description |
+| --- | --- | --- | --- | --- |
+| `Value` | `TValue` | `default` | No | Current checked value inherited from Blazor `InputBase<TValue>`. `null` is supported only when `TValue` is `bool?`. |
+| `ValueChanged` | `EventCallback<TValue>` | Empty callback | No | Receives values produced by user interaction and supports `@bind-Value`. |
+| `ValueExpression` | `Expression<Func<TValue>>?` | Generated fallback outside a form | No | Identifies the bound field for Blazor forms and validation. |
+| `DisplayName` | `string?` | `null` | No | Inherited Blazor input metadata used by validation infrastructure. |
+| `Label` | `string?` | `null` | No | Label used for the checked state and as the fallback label for unchecked and indeterminate states. |
+| `UncheckedLabel` | `string?` | `null` | No | Replaces `Label` while the value is `false`. |
+| `IndeterminateLabel` | `string?` | `null` | No | Replaces `Label` while a nullable value is `null`. |
+| `Required` | `string?` | `null` | No | Text rendered after the visible label, such as `*`. It does not add the HTML `required` attribute or a validation rule. |
+| `Circular` | `bool` | `false` | No | Uses a circular indicator instead of the default rounded-square indicator. |
+| `Size` | `CheckboxSize` | `CheckboxSize.Medium` | No | Indicator size. Values: `Medium`, `Large`. |
+| `LabelPosition` | `LabelPosition` | `LabelPosition.After` | No | Places the label after or before the indicator. Values: `After`, `Before`. |
+| `Class` | `string?` | `null` | No | Adds CSS classes to the component wrapper. |
+| `Style` | `string?` | `null` | No | Adds inline styles to the component wrapper. |
+| Unmatched attributes | `Dictionary<string, object>?` | `null` | No | Applied to the native checkbox input. Use this for attributes such as `id`, `disabled`, `aria-label`, `aria-describedby`, `name`, or `accesskey`. |
+
+## Events and binding
+
+| Event or binding | Type | When it occurs |
+| --- | --- | --- |
+| `@bind-Value` | `TValue` | Updates the bound value when the native checkbox raises `change`. |
+| `ValueChanged` | `EventCallback<TValue>` | Receives the new value through the inherited `InputBase<TValue>` binding contract. |
+
+The explicit form is:
+
+```razor
+<Checkbox Value="_accepted"
+          ValueChanged="OnAcceptedChanged"
+          Label="Accept the terms" />
+
+@code {
+    private bool _accepted;
+
+    private void OnAcceptedChanged(bool value)
+    {
+        _accepted = value;
+    }
+}
+```
+
+For `Checkbox<bool?>`, `null` renders the component's indeterminate visual and the indeterminate label. User interaction changes `null` to `true`, then toggles between `true` and `false`; there is no user gesture that restores `null`. Set the bound value to `null` in application code when an indeterminate state is needed.
+
+## Child content and composition
+
+`Checkbox` has no child-content slot. Supply label text through `Label`, `UncheckedLabel`, and `IndeterminateLabel`.
+
+The component can participate in an `EditForm` through its inherited `InputBase<TValue>` behavior. The `Required` parameter is only a visual text marker; use normal Blazor validation attributes or custom validation for required business rules.
+
+## Services and containers
+
+Use the standard `AddBluentUI()` registration described in [Getting Started](../getting-started/index.md). `<Containers />` is not required by `Checkbox`.
+
+The component has no direct JavaScript dependency during normal use. If an `accesskey` attribute is supplied, the inherited input base uses the registered DOM helper after first render to identify the operating system.
+
+## Styling and theming
+
+Include the standard theme and component bundles from [the theming and assets guide](../guides/theming-localization-rtl-and-assets.md). The source styles use Bluent design tokens for foreground, brand, disabled, spacing, typography, border radius, and indicator colors, so Checkbox follows the active Bluent light/dark token set.
+
+Use `Size`, `Circular`, `LabelPosition`, `Class`, and `Style` for the supported public customization surface. Internal selectors and generated state classes are implementation details, not a compatibility contract.
+
+## Localization and RTL
+
+Checkbox has no built-in localized strings or culture-sensitive formatting. Applications provide all label and required-marker text.
+
+The component has a targeted `[dir="rtl"]` rule that moves its transparent native input to the right. Label spacing uses a logical inline property for the required marker. Component-specific visual and interaction behavior in RTL has not been runtime verified.
+
+## Accessibility and keyboard interaction
+
+The source renders a native `<input type="checkbox">` and associates a rendered `<label>` with its generated or supplied `id`. The two indicator SVGs are marked `aria-hidden="true"`. A `disabled` unmatched attribute reaches the native input and also selects the component's disabled visual state when its value is `true`.
+
+Provide `Label` or an explicit accessible-name attribute such as `aria-label`. `Required` is visual text only and does not set `aria-required`.
+
+For a nullable `null` value, the source displays an indeterminate icon but does not set the native input's `indeterminate` property or `aria-checked="mixed"`. Assistive technology therefore must not be assumed to announce a mixed state. Native focus and Space-key behavior, validation announcements, and RTL keyboard behavior have not been independently runtime tested.
+
+## Hosting and render modes
+
+See [Hosting models and render modes](../compatibility/hosting-and-render-modes.md) for the repository-wide evidence and setup.
+
+| Render mode | Status | Notes |
+| --- | --- | --- |
+| Standalone WebAssembly | Verified | Checkbox binding was exercised in the compiled onboarding example. |
+| Interactive Server | Unverified | The representative mode baseline passed, but Checkbox-specific behavior was not separately recorded. |
+| Interactive WebAssembly | Unverified | The representative mode baseline passed, but Checkbox-specific behavior was not separately recorded. |
+| Interactive Auto | Unverified | The representative mode baseline passed, but Checkbox-specific behavior was not separately recorded. |
+| Static SSR | Limited | Markup can render, but user interaction and two-way binding require an interactive render mode. |
+
+## JavaScript and static assets
+
+Normal Checkbox interaction does not import a component-specific JavaScript module or require a manual script tag. It requires:
+
+- `_content/Bluent.UI/bluent.ui.theme.default.min.css` or another packaged Bluent theme;
+- `_content/Bluent.UI/bluent.ui.components.min.css`.
+
+The optional inherited `accesskey` handling uses the base package's dynamically imported module. There is no Checkbox-specific cleanup or browser API.
+
+## Common mistakes
+
+### A non-Boolean type throws during component construction
+
+Bind only `bool` or `bool?`. Checkbox validates its generic type in its constructor.
+
+### The nullable value never returns to indeterminate
+
+User interaction produces only `true` and `false`. Assign `null` from application code to restore the indeterminate visual state.
+
+### The required marker does not validate the field
+
+`Required` renders only the supplied marker text. Add the appropriate Blazor validation rule to the model.
+
+## Known limitations
+
+- The visual indeterminate state is not exposed as a native or ARIA mixed state.
+- User interaction cannot set the value back to `null`.
+- There is no child-content slot.
+- Component-specific keyboard, assistive-technology, RTL, and non-WebAssembly render-mode behavior remains unverified.
+
+## Related components
+
+- `RadioGroup` and `Switch` are listed in the [component inventory](inventory.md).
+- [Getting Started](../getting-started/index.md)
+- [Theming, localization, RTL, and browser assets](../guides/theming-localization-rtl-and-assets.md)
+
+## Source and verification
+
+- Component source: `src/Bluent.UI/Components/CheckBoxComponent/Checkbox.razor`
+- Component logic: `src/Bluent.UI/Components/CheckBoxComponent/Checkbox.razor.cs`
+- Styles: `src/Bluent.UI/Styles/Components/_checkbox.scss`
+- Compiled demo: `src/Bluent.UI.Demo.Pages/Pages/Components/Checkboxes.razor`
+- Compiled scenario: `src/Bluent.UI.Demo.Pages/Pages/Scenarios/CustomerProfile.razor`
+- Source verified against `Dev` commit `07e61ed8552176c1719ec94c81ea3fda867bae9e`
+- Verification date: 2026-07-26
+
+The API, example, styles, nullable behavior, and generated markup are source verified. The repository previously recorded standalone WebAssembly binding evidence; no new browser, visual, keyboard, or assistive-technology verification was performed for this page.

--- a/docs/components/inventory.md
+++ b/docs/components/inventory.md
@@ -37,13 +37,13 @@ Namespace: `Bluent.UI.Components`
 | ActionCard | `Bluent.UI` | `src/Bluent.UI/Components/ActionCardComponent/` | Not started | Verify | Not validated |
 | AudioCapture | `Bluent.UI` | `src/Bluent.UI/Components/AudioCaptureComponent/` | Not started | Verify | Not validated |
 | Avatar | `Bluent.UI` | `src/Bluent.UI/Components/AvatarComponent/` | Not started | Verify | Not validated |
-| Badge | `Bluent.UI` | `src/Bluent.UI/Components/BadgeComponent/` | Not started | Verify | Not validated |
+| [Badge](badge.md) | `Bluent.UI` | `src/Bluent.UI/Components/BadgeComponent/` | Source verified | Compiled demo | Build |
 | Breadcrumb | `Bluent.UI` | `src/Bluent.UI/Components/BreadcrumbComponent/` | Not started | Verify | Not validated |
 | Button | `Bluent.UI` | `src/Bluent.UI/Components/ButtonComponent/` | Not started | Verify | Not validated |
 | ButtonGroup | `Bluent.UI` | `src/Bluent.UI/Components/ButtonGroupComponent/` | Not started | Verify | Not validated |
 | Calendar | `Bluent.UI` | `src/Bluent.UI/Components/CalendarComponent/` | Not started | Verify | Not validated |
 | Card | `Bluent.UI` | `src/Bluent.UI/Components/CardComponent/` | Not started | Verify | Not validated |
-| Checkbox | `Bluent.UI` | `src/Bluent.UI/Components/CheckboxComponent/` | Not started | Verify | Not validated |
+| [Checkbox](checkbox.md) | `Bluent.UI` | `src/Bluent.UI/Components/CheckBoxComponent/` | Source verified | Compiled component demo and scenario | Runtime in standalone WebAssembly |
 | DataGrid | `Bluent.UI` | `src/Bluent.UI/Components/DataGridComponent/` | Not started | Verify | Not validated |
 | DataPager | `Bluent.UI` | `src/Bluent.UI/Components/DataPagerComponent/` | Not started | Verify | Not validated |
 | DateField | `Bluent.UI` | `src/Bluent.UI/Components/DateFieldComponent/` | Not started | Verify | Not validated |
@@ -148,13 +148,13 @@ Utilities includes services and abstractions in addition to Razor components. Th
 
 | Package | Tracked families/types | Source-verified references | Runtime-verified references | Automated examples |
 | --- | ---: | ---: | ---: | ---: |
-| `Bluent.UI` | 52 | 0 | 0 | 0 |
+| `Bluent.UI` | 52 | 2 | 1 | 2 |
 | `Bluent.UI.Charts` | 10 | 0 | 0 | 0 |
 | `Bluent.UI.Diagrams` | 5 | 0 | 0 | 0 |
 | `Bluent.UI.Utilities` | 4 | 0 | 0 | 0 |
-| **Total** | **71** | **0** | **0** | **0** |
+| **Total** | **71** | **2** | **1** | **2** |
 
-The zero baseline is intentional: a demo page or public source file is not counted as canonical documentation until it is reviewed against the [component reference template](TEMPLATE.md).
+Badge and Checkbox now have source-verified canonical references, while Dialog retains its separately recorded runtime verification. A demo page or public source file is not counted as canonical documentation until it is reviewed against the [component reference template](TEMPLATE.md).
 
 ## Prioritization
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,6 +15,8 @@ Bluent is open source under Apache License 2.0. The current repository targets .
 ## Components
 
 - [Component documentation index](https://github.com/vrassouli/Bluent/blob/Dev/docs/components/README.md): entry point for component references
+- [Badge](https://github.com/vrassouli/Bluent/blob/Dev/docs/components/badge.md): values, appearance, color, shape, icon/text behavior, styling, and accessibility limitations
+- [Checkbox](https://github.com/vrassouli/Bluent/blob/Dev/docs/components/checkbox.md): Boolean binding, nullable and indeterminate behavior, labels, styling, and accessibility limitations
 - [Dialog](https://github.com/vrassouli/Bluent/blob/Dev/docs/components/dialog.md): service usage, results, modal configuration, and nested dialog stacking
 - [Component inventory](https://github.com/vrassouli/Bluent/blob/Dev/docs/components/inventory.md): tracked public component families and documentation coverage
 - [Component reference standard](https://github.com/vrassouli/Bluent/blob/Dev/docs/components/TEMPLATE.md): required structure and verification rules for component pages

--- a/scripts/release/test_release_tools.py
+++ b/scripts/release/test_release_tools.py
@@ -1,16 +1,107 @@
 #!/usr/bin/env python3
 
+import json
+import re
 import tempfile
 import unittest
+import zipfile
 from argparse import Namespace
+from contextlib import contextmanager
 from pathlib import Path
 import sys
+from xml.etree import ElementTree
 
 sys.path.insert(0, str(Path(__file__).parent))
 import release_tools
 
 
 class ReleaseToolsTests(unittest.TestCase):
+    PACKAGE_VERSION = "1.2.3"
+    REPOSITORY_COMMIT = "0123456789abcdef"
+
+    @staticmethod
+    def _write_package(
+        directory: Path,
+        package_file_id: str,
+        *,
+        package_id: str | None = None,
+        version: str = PACKAGE_VERSION,
+        repository_commit: str = REPOSITORY_COMMIT,
+        include_readme: bool = True,
+        dependency_versions: dict[str, str] | None = None,
+    ) -> None:
+        package_id = package_id or package_file_id
+        dependency_versions = dependency_versions or {
+            dependency: version
+            for dependency in release_tools.PACKAGE_DEPENDENCIES[package_file_id]
+        }
+
+        package = ElementTree.Element("package")
+        metadata = ElementTree.SubElement(package, "metadata")
+        for name, value in (
+            ("id", package_id),
+            ("version", version),
+            ("authors", "Bluent test"),
+            ("description", "Synthetic package-validator fixture."),
+            ("projectUrl", "https://github.com/vrassouli/Bluent"),
+            ("readme", "README.md"),
+        ):
+            ElementTree.SubElement(metadata, name).text = value
+        license_element = ElementTree.SubElement(
+            metadata, "license", {"type": "expression"}
+        )
+        license_element.text = "Apache-2.0"
+        ElementTree.SubElement(
+            metadata,
+            "repository",
+            {
+                "type": "git",
+                "url": "https://github.com/vrassouli/Bluent.git",
+                "commit": repository_commit,
+            },
+        )
+        dependencies = ElementTree.SubElement(metadata, "dependencies")
+        group = ElementTree.SubElement(
+            dependencies, "group", {"targetFramework": "net10.0"}
+        )
+        for dependency_id, dependency_version in sorted(
+            dependency_versions.items()
+        ):
+            ElementTree.SubElement(
+                group,
+                "dependency",
+                {"id": dependency_id, "version": dependency_version},
+            )
+
+        package_path = directory / f"{package_file_id}.{version}.nupkg"
+        with zipfile.ZipFile(
+            package_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
+            archive.writestr(
+                f"{package_file_id}.nuspec",
+                ElementTree.tostring(package, encoding="utf-8", xml_declaration=True),
+            )
+            if include_readme:
+                archive.writestr("README.md", f"# {package_id}\n")
+            archive.writestr(f"lib/net10.0/{package_file_id}.dll", b"fixture")
+
+    @contextmanager
+    def _package_fixture(self, **overrides: dict[str, object]):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for package_id in release_tools.PACKAGE_DEPENDENCIES:
+                self._write_package(
+                    root,
+                    package_id,
+                    **overrides.get(package_id, {}),
+                )
+            yield Namespace(
+                directory=root,
+                version=self.PACKAGE_VERSION,
+                commit=self.REPOSITORY_COMMIT,
+                report=root / "package-validation.json",
+            )
+
     def test_accepts_stable_and_prerelease_versions(self) -> None:
         release_tools.validate_version("1.2.3")
         release_tools.validate_version("2.0.0-preview.1")
@@ -121,6 +212,80 @@ Historical prose.
                     release_tools.validate_readme_images(
                         f"![Example]({source})", "Bluent.UI"
                     )
+
+    def test_package_validator_accepts_valid_synthetic_packages(self) -> None:
+        with self._package_fixture() as args:
+            release_tools.validate_packages(args)
+
+            report = json.loads(args.report.read_text(encoding="utf-8"))
+            self.assertEqual(report["version"], self.PACKAGE_VERSION)
+            self.assertEqual(
+                {package["id"] for package in report["packages"]},
+                set(release_tools.PACKAGE_DEPENDENCIES),
+            )
+
+    def test_package_validator_rejects_wrong_package_id(self) -> None:
+        with self._package_fixture(
+            **{"Bluent.UI.Core": {"package_id": "Bluent.Wrong"}}
+        ) as args:
+            with self.assertRaisesRegex(
+                ValueError,
+                re.escape("has unexpected package ID 'Bluent.Wrong'"),
+            ):
+                release_tools.validate_packages(args)
+
+    def test_package_validator_rejects_wrong_version(self) -> None:
+        with self._package_fixture(
+            **{"Bluent.UI": {"version": "9.9.9"}}
+        ) as args:
+            with self.assertRaisesRegex(
+                ValueError,
+                re.escape(
+                    "Bluent.UI has version '9.9.9', expected "
+                    f"'{self.PACKAGE_VERSION}'"
+                ),
+            ):
+                release_tools.validate_packages(args)
+
+    def test_package_validator_rejects_missing_readme(self) -> None:
+        with self._package_fixture(
+            **{"Bluent.UI": {"include_readme": False}}
+        ) as args:
+            with self.assertRaisesRegex(
+                ValueError,
+                re.escape("Bluent.UI does not contain README.md"),
+            ):
+                release_tools.validate_packages(args)
+
+    def test_package_validator_rejects_mismatched_repository_commit(self) -> None:
+        with self._package_fixture(
+            **{"Bluent.UI": {"repository_commit": "wrong-commit"}}
+        ) as args:
+            with self.assertRaisesRegex(
+                ValueError,
+                re.escape(
+                    "Bluent.UI repository commit does not match "
+                    f"{self.REPOSITORY_COMMIT}"
+                ),
+            ):
+                release_tools.validate_packages(args)
+
+    def test_package_validator_rejects_unaligned_bluent_dependency(self) -> None:
+        with self._package_fixture(
+            **{
+                "Bluent.UI": {
+                    "dependency_versions": {"Bluent.UI.Core": "9.9.9"}
+                }
+            }
+        ) as args:
+            with self.assertRaisesRegex(
+                ValueError,
+                re.escape(
+                    "Bluent.UI requires Bluent.UI.Core at ['9.9.9'], "
+                    f"expected exact version {self.PACKAGE_VERSION}"
+                ),
+            ):
+                release_tools.validate_packages(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome

Adds canonical, source-verified Checkbox and Badge references and expands package-validator coverage with temporary synthetic NuGet archives. No component source, public API, package, workflow, tag, or release behavior changes.

## Changed files

- `.bluent/PROJECT.md` — records the cleanup scope and validation evidence.
- `docs/components/badge.md` — documents current Badge parameters, enum values, rendering, styling, RTL, accessibility, hosting, and limitations.
- `docs/components/checkbox.md` — documents current Checkbox binding, Boolean/nullable behavior, labels, styling, RTL, accessibility, hosting, and limitations.
- `docs/components/README.md` — links the two canonical references.
- `docs/components/inventory.md` — marks Badge and Checkbox source verified and updates coverage counts.
- `llms.txt` — adds both canonical pages to the machine-readable index.
- `scripts/release/test_release_tools.py` — creates temporary standard-library `.nupkg` fixtures and tests valid, wrong-ID, wrong-version, missing-README, commit-mismatch, and unaligned-dependency cases.

## Validation

- `python3 -m unittest -v scripts/release/test_release_tools.py` — passed, 13/13.
- `python3 scripts/quality/check_markdown_links.py` — passed, 36 Markdown files.
- `dotnet restore Bluent.sln` — passed; all projects up to date.
- `dotnet build Bluent.sln --configuration Release --no-restore -warnaserror` — passed, 0 warnings and 0 errors.
- `dotnet test Bluent.sln --configuration Release --no-build` — passed, 19/19.
- `git diff --check origin/Dev` — passed.

## Verification scope and risk

- Documentation claims were checked against current component, base-class, style, icon, service-registration, and demo source at `Dev` commit `07e61ed8552176c1719ec94c81ea3fda867bae9e`.
- The existing standalone WebAssembly Checkbox-binding evidence is identified separately from source/build verification.
- No new Badge or Checkbox browser, visual, keyboard, assistive-technology, or component-specific cross-render-mode run was performed; those gaps are explicit in the pages.
- No breaking change or migration step is required.
- No packages were published and no tag or GitHub Release was created.

Closes #374
Closes #375
Closes #376
