### PR TITLE
Validate render-mode reconnection, overlays, focus, and measurement

### DIFF
--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -105,6 +105,8 @@ Before any production publication, the maintainer still must:
   follow-up work on `test/render-mode-followups`, based on `Dev` commit
   `782ddad1f082ead94d020e03e95a4c803d4bbbb9`. The probe source exercised at
   runtime is commit `848a083e4341b26fbf4d394ffea123157b03aa6c`.
+  [PR #389](https://github.com/vrassouli/Bluent/pull/389) is open and
+  non-draft against `Dev`.
 - Issue #366 remains open only for work not covered by those focused issues,
   including exact Interactive Auto renderer-transition timing if the
   maintainer still requires instrumentation.

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -100,7 +100,14 @@ Before any production publication, the maintainer still must:
 
 ## Deferred Work
 
-- Issue #366 remains open for transient Interactive Server reconnection and exact Interactive Auto renderer-transition instrumentation.
+- Issues [#387](https://github.com/vrassouli/Bluent/issues/387) and
+  [#388](https://github.com/vrassouli/Bluent/issues/388) have runtime-complete
+  follow-up work on `test/render-mode-followups`, based on `Dev` commit
+  `782ddad1f082ead94d020e03e95a4c803d4bbbb9`. The probe source exercised at
+  runtime is commit `848a083e4341b26fbf4d394ffea123157b03aa6c`.
+- Issue #366 remains open only for work not covered by those focused issues,
+  including exact Interactive Auto renderer-transition timing if the
+  maintainer still requires instrumentation.
 - Issue #363 remains separate AI-readiness work.
 - Community outreach, new public components, and Sprint 4 have not started.
 

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -219,6 +219,50 @@ Known deferred compatibility work remains tracked in Issue #366, including trans
 - The diff against `origin/Dev` passed `git diff --check`.
 - No package, tag, GitHub Release, or product API was created or published.
 
+## Post-Sprint 3 Render-Mode Follow-ups
+
+**Issues:** [#387](https://github.com/vrassouli/Bluent/issues/387) and
+[#388](https://github.com/vrassouli/Bluent/issues/388)
+
+**Branch:** `test/render-mode-followups`
+
+### Completed on branch
+
+- [x] Reproduce a transient Interactive Server transport interruption without
+  terminating the ASP.NET host.
+- [x] Verify automatic circuit reconnection, preserved binding/callback state,
+  post-reconnect dialog/toast services, and post-reconnect JavaScript-backed
+  popover behavior.
+- [x] Verify representative Drawer close/navigation/disposal, Popover
+  placement/dismissal, Tooltip focus/cleanup, and DOM-measurement scenarios in
+  Interactive Server, Interactive WebAssembly, and Interactive Auto.
+- [x] Record the Interactive Auto renderer observed by the interactive
+  component instance without claiming transition timing.
+- [x] Reconfirm meaningful static SSR display-only output and document
+  interactive behavior there as unsupported.
+- [x] Update the canonical hosting/render-mode evidence with exact environment,
+  steps, actual results, console/server findings, and limitations.
+
+### Runtime evidence
+
+- Runtime probe commit:
+  `848a083e4341b26fbf4d394ffea123157b03aa6c`.
+- The Interactive Server circuit automatically rejoined after the forwarding
+  layer was unavailable for approximately 10 seconds; state was preserved and
+  overlays plus JavaScript-backed placement worked after recovery.
+- Drawer, Popover, Tooltip, focus movement, navigation, and disposal checks
+  passed in all three interactive modes. Interactive Auto reported WebAssembly
+  for the tested instance.
+- Fresh matrix tabs had no browser-console warning or error. The reconnection
+  tab recorded only the expected transport and retry failures during the
+  simulated outage. The server remained alive and logged no circuit or
+  component exception.
+- Markdown links passed across 36 maintained files.
+- Solution restore passed; the Release build passed with warnings treated as
+  errors: 0 warnings, 0 errors; and application tests passed 19/19.
+- The diff against `origin/Dev` passed `git diff --check`.
+- The non-draft review pull request is pending.
+
 ## Stable Release 1.0.367
 
 **Tracking:** [Issue #381](https://github.com/vrassouli/Bluent/issues/381)

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -226,6 +226,9 @@ Known deferred compatibility work remains tracked in Issue #366, including trans
 
 **Branch:** `test/render-mode-followups`
 
+**Pull Request:** [#389](https://github.com/vrassouli/Bluent/pull/389) — open
+for review
+
 ### Completed on branch
 
 - [x] Reproduce a transient Interactive Server transport interruption without
@@ -261,7 +264,8 @@ Known deferred compatibility work remains tracked in Issue #366, including trans
 - Solution restore passed; the Release build passed with warnings treated as
   errors: 0 warnings, 0 errors; and application tests passed 19/19.
 - The diff against `origin/Dev` passed `git diff --check`.
-- The non-draft review pull request is pending.
+- The non-draft [PR #389](https://github.com/vrassouli/Bluent/pull/389)
+  targets `Dev` and remains open for review.
 
 ## Stable Release 1.0.367
 

--- a/docs/compatibility/hosting-and-render-modes.md
+++ b/docs/compatibility/hosting-and-render-modes.md
@@ -26,9 +26,9 @@ every component has been tested in every mode.
 | --- | --- | --- | --- | --- |
 | Standalone Blazor WebAssembly | `src/Bluent.UI.Demo` | Passed in the full Release solution build | Debug local host rendered the compiled onboarding example; checkbox binding, callback state, dialog overlay, navigation, and clean console were checked | Verified onboarding path |
 | Static server-side rendering | `/compatibility/static` in `src/Bluent.UI.Demo.SSR` | Passed | Heading, information message, and styled display-only button rendered without an interactive boundary | Verified for display-only use, not events or browser interop |
-| Interactive Server | `/compatibility/server` | Passed | Prerender/hydration, text binding, callback count, dialog, toast, chart canvas, diagram SVG, navigation, disposal, and clean console passed | Representative baseline passed |
-| Interactive WebAssembly | `/compatibility/webassembly` | Passed | Prerender/hydration, text binding, callback count, dialog, toast, chart canvas, diagram SVG, and clean console passed | Representative baseline passed |
-| Interactive Auto | `/compatibility/auto` | Passed | Initial interactive visit passed binding, callback, dialog, toast, chart, diagram, and clean-console checks | Representative baseline passed; renderer-transition timing was not separately instrumented |
+| Interactive Server | `/compatibility/server` | Passed | Prerender/hydration, stateful binding, callbacks, dialog, toast, drawer, popover, tooltip focus/cleanup, chart canvas, diagram SVG, navigation, disposal, transient circuit reconnection, and post-reconnect interaction passed | Verified representative baseline; not an exhaustive component matrix |
+| Interactive WebAssembly | `/compatibility/webassembly` | Passed | Prerender/hydration, binding, callbacks, drawer, popover placement, tooltip focus/cleanup, chart canvas, diagram SVG, navigation, disposal, and clean console passed | Verified representative baseline; not an exhaustive component matrix |
+| Interactive Auto | `/compatibility/auto` | Passed | The tested interactive instance reported WebAssembly and passed drawer, popover placement, tooltip focus/cleanup, navigation, disposal, and clean-console checks | Verified representative baseline for the observed renderer; exact renderer-transition timing was not instrumented |
 
 ## Reproducible consumer structure
 
@@ -77,6 +77,9 @@ The shared compatibility probe uses current public APIs to cover:
 - a `TextField` with `@bind-Value` and `BindValueEvent="oninput"`;
 - a `Button` callback that updates visible state;
 - `IToastService` and `IDialogService`;
+- `IDrawerService`, including close and navigation from drawer content;
+- a bottom-placed, same-width `Popover`;
+- a focus-activated `Tooltip`;
 - a Chart.js-backed `Chart`;
 - a JavaScript-backed `Diagram`;
 - a `NavLink` from an interactive route to the static SSR route; and
@@ -91,6 +94,54 @@ The standalone WebAssembly demo's compiled Getting Started example exercised
 checkbox binding, enabled-state propagation, a save callback, and a dialog. Its
 fresh Debug-host browser tab had no warning or error console entries.
 
+## Follow-up status vocabulary
+
+The focused follow-up matrix uses these terms:
+
+- **Verified** — the stated representative behavior was exercised at runtime
+  in the named mode.
+- **Limited** — a narrower behavior was verified, but a related behavior such
+  as focus restoration was not exposed or measured.
+- **Unsupported** — the behavior requires browser interactivity and therefore
+  cannot function in static SSR.
+- **Unverified** — no runtime evidence was collected for the specific
+  combination.
+
+These labels apply only to the scenarios below. They do not generalize from one
+representative component to every Bluent component.
+
+## Overlay, focus, and DOM-measurement follow-up
+
+Evidence was collected from the probe source at commit
+`848a083e4341b26fbf4d394ffea123157b03aa6c`.
+
+| Scenario | Interactive Server | Interactive WebAssembly | Interactive Auto | Static SSR |
+| --- | --- | --- | --- | --- |
+| Drawer open and close | **Verified.** The service-backed drawer opened, its content rendered, its close action returned `closed`, and its DOM detached. | **Verified.** Same result. | **Verified.** Same result with the interactive instance reporting WebAssembly. | **Unsupported.** Service-backed open/close requires an interactive boundary. |
+| Drawer navigation and disposal | **Verified.** Navigation from inside the reopened drawer reached `/compatibility/static`; no `.bui-drawer` remained. | **Verified.** Same result. | **Verified.** Same result with the observed WebAssembly renderer. | **Unsupported.** There is no interactive drawer to dispose. |
+| Popover placement and dismissal | **Verified.** The bottom popover rendered 6 px below its trigger, matched the trigger width, then dismissed and detached on an outside click. | **Verified.** Same measured result. | **Verified.** Same measured result with the observed WebAssembly renderer. | **Unsupported.** Placement, event handling, and cleanup require JavaScript and interactivity. |
+| Tooltip activation and cleanup | **Verified.** Focusing the trigger displayed the tooltip; moving focus to the Increment button removed it. | **Verified.** Same result. | **Verified.** Same result with the observed WebAssembly renderer. | **Unsupported.** Focus-driven activation and cleanup require interactivity. |
+| Focus behavior or restoration | **Limited.** Trigger focus and focus moving to another button were observed. No focus-restoration contract was exercised. | **Limited.** Same result. | **Limited.** Same result with the observed WebAssembly renderer. | **Unsupported** for interactive focus management. |
+| DOM measurement | **Verified.** Floating UI produced a 6 px vertical gap and a 0 px width difference for `Placement.Bottom` plus `SameWidth`. | **Verified.** Same measurements. | **Verified.** Same measurements with the observed WebAssembly renderer. | **Unsupported.** Static markup does not run the measurement lifecycle. |
+| Meaningful display-only output | Not the purpose of this interactive row. | Not the purpose of this interactive row. | Not the purpose of this interactive row. | **Verified.** The heading, information message, and styled display-only button rendered. |
+
+The placement measurements were identical in the three tested interactive
+tabs: trigger bottom `376.1875`, surface top `382.1875`, vertical gap `6`, and
+trigger/surface width `200.890625`. Those coordinates are observations from
+one browser surface and viewport, not a guarantee of fixed coordinates.
+
+Each interactive scenario used a fresh tab. After drawer navigation, the
+static-route heading was visible and the drawer count was zero. The fresh-tab
+warning/error console was empty in all three interactive modes and in the
+static SSR display-only check. No server-side component or circuit exception
+was logged during this matrix.
+
+Interactive Auto's runtime marker used `OperatingSystem.IsBrowser()` in the
+interactive component instance. It reported `WebAssembly` for the recorded
+matrix run. This identifies the renderer that executed the tested instance; it
+does not instrument or claim the time at which Auto selected or transitioned
+to that renderer.
+
 ## Prerender and lifecycle observations
 
 - All three interactive Blazor Web App pages produced their initial heading,
@@ -103,9 +154,57 @@ fresh Debug-host browser tab had no warning or error console entries.
 - A process restart during the first test intentionally broke the existing
   circuit and produced expected stale connection errors in that original tab.
   Fresh-tab checks were used for the clean-console results.
-- Server-circuit reconnection across a transient network interruption was not
-  automated in this pass. A process restart is not a valid successful
-  reconnection test because server memory and circuit state are lost.
+- A later focused test validated transient Interactive Server reconnection
+  without restarting the server, as detailed below.
+
+## Transient Interactive Server reconnection
+
+**Status: Verified representative scenario.** The source tree exercised at
+runtime is commit `848a083e4341b26fbf4d394ffea123157b03aa6c`.
+
+Expected behavior was that a short transport outage would show Blazor's
+reconnection UI, automatically rejoin the existing circuit after transport
+restoration, preserve circuit state, and leave Bluent overlays and
+JavaScript-backed behavior usable.
+
+The exact procedure was:
+
+1. Start the Release-built ASP.NET host on `127.0.0.1:5054` and leave that
+   process running.
+2. Start a local TCP forwarding process on `127.0.0.1:5056` and open
+   `/compatibility/server` through that forwarding port.
+3. Change the bound value from `ready` to `circuit-state-387`, increment the
+   event count to `1`, show and dismiss a dialog, show a toast, and confirm one
+   chart canvas and one diagram SVG.
+4. Send `SIGUSR1` to the forwarding process. This destroyed its active sockets
+   and stopped its listener without signaling or terminating the ASP.NET host.
+5. Keep the forwarding port unavailable through several automatic reconnect
+   attempts, for approximately 10 seconds.
+6. Send `SIGUSR2` to the same forwarding process to restore its listener, then
+   wait for automatic reconnection without reloading the page.
+7. Confirm that the reconnection UI disappeared, the bound value remained
+   `circuit-state-387`, the event count remained `1`, and the chart and diagram
+   DOM remained present.
+8. Increment again to `2`, show a new toast, show and dismiss a new dialog, and
+   open and dismiss the JavaScript-backed popover.
+
+Actual behavior matched that expectation. The circuit rejoined automatically;
+the stateful value and callback count were preserved rather than reset; both
+overlay services remained functional; and the post-reconnect popover measured
+and rendered 6 px below its trigger with the same `200.890625` px width before
+cleanly detaching.
+
+During the interruption, the UI reported `Rejoin failed... trying again in 3
+seconds`. The browser console recorded the expected WebSocket close `1006`,
+`Failed to fetch`, and failed negotiation/start messages while the forwarding
+port was unavailable. No additional Bluent component error was recorded after
+recovery. The server log contained only the existing startup warning that an
+HTTPS redirect port could not be determined; it contained no circuit,
+component, or unhandled exception, and the same server PID remained alive.
+
+This is a single-circuit, short-interruption test. It does not validate process
+restart, circuit retention beyond the framework retention window, scale-out,
+multi-node routing, proxy buffering, load, or chaos behavior.
 
 ## Static SSR limitations
 
@@ -174,6 +273,90 @@ dotnet run \
   --urls http://127.0.0.1:5055
 ```
 
+Follow-up evidence for Issues
+[#387](https://github.com/vrassouli/Bluent/issues/387) and
+[#388](https://github.com/vrassouli/Bluent/issues/388) was collected on
+2026-07-26 with:
+
+- source commit:
+  `848a083e4341b26fbf4d394ffea123157b03aa6c`;
+- base commit:
+  `782ddad1f082ead94d020e03e95a4c803d4bbbb9` from the latest fetched `Dev`;
+- macOS 26.5.2 (`25F84`) on Apple Silicon (`arm64`);
+- .NET SDK `10.0.300`;
+- .NET and ASP.NET Core runtime `10.0.8`;
+- Codex in-app browser using its Chromium-based engine; the automation surface
+  did not expose the exact Chromium build;
+- an observed browser viewport of 580 x 905 CSS pixels for the recorded
+  placement measurement;
+- ASP.NET Core `Development` environment.
+
+The follow-up host was built and launched with:
+
+```bash
+dotnet build src/Bluent.UI.Demo.SSR/Bluent.UI.Demo.SSR.csproj \
+  --configuration Release \
+  --no-restore \
+  -warnaserror
+
+ASPNETCORE_ENVIRONMENT=Development \
+  dotnet run \
+  --project src/Bluent.UI.Demo.SSR/Bluent.UI.Demo.SSR.csproj \
+  --configuration Release \
+  --no-build \
+  --no-launch-profile \
+  --urls http://127.0.0.1:5054
+```
+
+The transient-interruption forwarding process used Node's `net` module. It
+printed its PID, destroyed all tracked sockets and closed its listener on
+`SIGUSR1`, and listened again on `SIGUSR2`:
+
+```bash
+node -e '
+const net = require("net");
+const sockets = new Set();
+let server;
+function listen() {
+  server = net.createServer(client => {
+    const upstream = net.connect(5054, "127.0.0.1");
+    sockets.add(client);
+    sockets.add(upstream);
+    client.pipe(upstream);
+    upstream.pipe(client);
+    const done = () => {
+      sockets.delete(client);
+      sockets.delete(upstream);
+      client.destroy();
+      upstream.destroy();
+    };
+    client.on("error", done);
+    upstream.on("error", done);
+    client.on("close", done);
+    upstream.on("close", done);
+  });
+  server.on("error", error => console.error("proxy error", error.message));
+  server.listen(5056, "127.0.0.1",
+    () => console.log(`proxy listening pid=${process.pid}`));
+}
+process.on("SIGUSR1", () => {
+  console.log("proxy interrupted");
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  if (server) server.close();
+});
+process.on("SIGUSR2", () => {
+  console.log("proxy restored");
+  listen();
+});
+listen();
+setInterval(() => {}, 1000);
+'
+
+kill -USR1 <proxy-pid>
+kill -USR2 <proxy-pid>
+```
+
 ## Known limitations and follow-up
 
 - The standalone demo's Release index uses the deployed `/Bluent/` base path.
@@ -182,9 +365,14 @@ dotnet run \
   validate the published Release output under `/Bluent/`.
 - Exact Interactive Auto server-to-WebAssembly transition timing was not
   instrumented; the public behavior passed.
-- Transient Interactive Server reconnection remains a focused follow-up.
-- Drawer, popover, tooltip, focus restoration, and every component-specific
-  disposal path were not exhaustively retested in all modes.
+- Focus restoration was not verified because the tested Drawer, Popover, and
+  Tooltip scenarios did not expose a documented restoration contract.
+- Only the representative Drawer, Popover, and Tooltip scenarios described
+  above were checked; other overlays and component-specific disposal paths
+  remain unverified.
+- The follow-up used one Chromium-based browser surface and one viewport. Other
+  browsers, viewport sizes, input methods, assistive technologies, and
+  long-lived circuit interruptions remain unverified.
 - This representative baseline does not claim complete browser coverage or
   complete WCAG conformance.
 - CI performs focused rendered-markup checks for a language declaration, one
@@ -197,6 +385,7 @@ dotnet run \
 - `src/Bluent.UI.Demo/Program.cs`
 - `src/Bluent.UI.Demo/wwwroot/index.html`
 - `src/Bluent.UI.Demo.Interactive.Client/Program.cs`
+- `src/Bluent.UI.Demo.Interactive.Client/Shared/CompatibilityDrawerContent.razor`
 - `src/Bluent.UI.Demo.Interactive.Client/Shared/CompatibilityProbe.razor`
 - `src/Bluent.UI.Demo.Interactive.Client/Pages/`
 - `src/Bluent.UI.Demo.SSR/Program.cs`

--- a/src/Bluent.UI.Demo.Interactive.Client/Shared/CompatibilityDrawerContent.razor
+++ b/src/Bluent.UI.Demo.Interactive.Client/Shared/CompatibilityDrawerContent.razor
@@ -1,0 +1,23 @@
+<div style="display: grid; gap: 1rem; padding: 1rem;">
+    <p>
+        This drawer content validates close, navigation, and disposal in the
+        active interactive render boundary.
+    </p>
+    <Button Text="Close drawer"
+            Appearance="ButtonAppearance.Primary"
+            OnClick="Close"
+            data-testid="drawer-close" />
+    <NavLink href="/compatibility/static"
+             data-testid="drawer-navigate">
+        Navigate from drawer to static SSR probe
+    </NavLink>
+</div>
+
+@code {
+    [CascadingParameter] public Drawer? Drawer { get; set; }
+
+    private void Close()
+    {
+        Drawer?.Close("closed");
+    }
+}

--- a/src/Bluent.UI.Demo.Interactive.Client/Shared/CompatibilityProbe.razor
+++ b/src/Bluent.UI.Demo.Interactive.Client/Shared/CompatibilityProbe.razor
@@ -1,4 +1,5 @@
 @inject IDialogService DialogService
+@inject IDrawerService DrawerService
 @inject IToastService ToastService
 
 <PageTitle>@Mode compatibility | Bluent</PageTitle>
@@ -8,6 +9,7 @@
     This minimal consumer validates Bluent registration, component imports,
     styles, event callbacks, binding, overlays, charts, diagrams, and disposal.
 </p>
+<p data-testid="observed-renderer">Observed interactive renderer: @_observedRenderer</p>
 
 <section aria-labelledby="interaction-heading">
     <h2 id="interaction-heading">Interaction</h2>
@@ -19,7 +21,29 @@
         <Button Text="Increment" OnClick="Increment" Appearance="ButtonAppearance.Primary" />
         <Button Text="Show toast" OnClick="ShowToast" />
         <Button Text="Show dialog" OnClick="ShowDialog" />
+        <Button Text="Open drawer" OnClick="ShowDrawer" data-testid="drawer-trigger" />
         <NavLink href="/compatibility/static">Navigate to static SSR probe</NavLink>
+    </div>
+    <p role="status" data-testid="drawer-result">Drawer result: @_drawerResult</p>
+</section>
+
+<section aria-labelledby="overlay-heading">
+    <h2 id="overlay-heading">Placement and focus</h2>
+    <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; margin-block: 1rem;">
+        <Popover Placement="Placement.Bottom" SameWidth>
+            <Trigger>
+                <Button Text="Toggle measured popover" data-testid="popover-trigger" />
+            </Trigger>
+            <Surface>
+                <div data-testid="popover-surface">
+                    Placement-dependent popover content.
+                </div>
+            </Surface>
+        </Popover>
+        <Button Text="Focus tooltip trigger"
+                Tooltip="@($"{Mode} focus tooltip")"
+                TooltipPlacement="Placement.Top"
+                data-testid="tooltip-trigger" />
     </div>
 </section>
 
@@ -61,6 +85,9 @@
 
     private string _value = "ready";
     private int _count;
+    private string _drawerResult = "not opened";
+    private readonly string _observedRenderer =
+        OperatingSystem.IsBrowser() ? "WebAssembly" : "Server";
     private readonly Dictionary<string, double> _chartData = new()
     {
         ["First"] = 2,
@@ -85,5 +112,13 @@
         await DialogService.ShowMessageBoxAsync(
             $"{Mode} dialog",
             "Dialog service resolved in the active interactive scope.");
+    }
+
+    private async Task ShowDrawer()
+    {
+        _drawerResult = "open";
+        var result = await DrawerService.ShowAsync<CompatibilityDrawerContent>(
+            $"{Mode} drawer");
+        _drawerResult = result?.ToString() ?? "dismissed";
     }
 }


### PR DESCRIPTION
## User-visible outcome

Completes the focused render-mode follow-ups with a reproducible compatibility probe and evidence-qualified documentation. No public Bluent API, package, tag, release, or publication behavior changes.

## Source and environment

- Base: latest fetched `Dev` at `782ddad1f082ead94d020e03e95a4c803d4bbbb9`
- Runtime probe commit: `848a083e4341b26fbf4d394ffea123157b03aa6c`
- macOS 26.5.2 (`25F84`), Apple Silicon (`arm64`)
- .NET SDK 10.0.300
- .NET / ASP.NET Core runtime 10.0.8
- Codex in-app Chromium-based browser; the browser surface did not expose the exact Chromium build
- Observed placement viewport: 580 x 905 CSS pixels
- Host: ASP.NET Core Development environment at `http://127.0.0.1:5054`

## Issue #387 — transient Interactive Server reconnection

### Exact scenario

1. Started the Release-built Interactive Server consumer and left the ASP.NET process running.
2. Opened `/compatibility/server` through a local TCP forwarder on port 5056.
3. Changed the bound value to `circuit-state-387`, incremented callback state to `1`, exercised dialog and toast services, and confirmed one chart canvas and one diagram SVG.
4. Sent `SIGUSR1` only to the forwarding process, which destroyed its active sockets and stopped listening. The ASP.NET server process was not signaled or terminated.
5. Kept the forwarding port unavailable through several reconnect attempts for approximately 10 seconds.
6. Sent `SIGUSR2` to restore the forwarding listener and waited without reloading.
7. Verified automatic reconnect, preserved bound value and callback state, then incremented to `2`, opened a new toast and dialog, and exercised the JavaScript-backed popover.

### Result

- Automatic reconnect: passed.
- State preservation: `circuit-state-387` and count `1` survived; the next callback produced count `2`.
- Overlay services: toast and dialog worked before and after reconnect.
- JavaScript-backed behavior: the post-reconnect popover rendered 6 px below its trigger, matched the trigger width at `200.890625` px, dismissed, and detached.
- Browser console: clean before interruption; during interruption it recorded the expected WebSocket close 1006, failed fetch, and negotiation/start retry messages. No additional Bluent component error appeared after recovery.
- Server logs: the same server PID remained alive. The only message was the existing HTTPS redirect-port startup warning; no circuit, component, or unhandled exception was logged.

## Issue #388 — overlay, focus, and DOM-measurement matrix

The same representative script ran in fresh tabs for Interactive Server, Interactive WebAssembly, and Interactive Auto:

- Drawer: opened, rendered content, closed with result `closed`, detached, reopened, navigated from inside the drawer to `/compatibility/static`, and left zero drawer elements after navigation/disposal.
- Popover: bottom placement measured a 6 px trigger-to-surface gap and zero width difference with `SameWidth`; outside click dismissed and detached it.
- Tooltip/focus: focusing the trigger displayed the tooltip; moving focus to the Increment button removed it.
- Console: no warning or error in the recorded fresh matrix tabs.
- Renderer: Server reported Server; Interactive WebAssembly reported WebAssembly; the recorded Interactive Auto interactive instance reported WebAssembly.
- Static SSR: heading, information message, and styled display-only button rendered with a clean console. Interactive drawer/popover/tooltip/focus/measurement behavior is explicitly documented as unsupported in static SSR.

## Failures, limitations, and unverified behavior

- One initial Interactive Auto automation action occurred before the page became interactive and did not open the popover. That attempt was discarded; the recorded fresh tab waited for the WebAssembly renderer marker and passed the complete matrix with a clean console.
- Interactive Auto renderer-transition timing was not instrumented and is not claimed.
- Focus activation and movement were verified, but no focus-restoration contract was exposed or claimed for the tested components.
- Evidence covers one Chromium-based browser surface and one viewport, not every browser, viewport, input method, assistive technology, overlay component, or disposal path.
- The reconnection scenario covers one circuit and a short transport outage, not process restart, retention-window expiry, scale-out, multi-node routing, proxy buffering, load, or chaos behavior.

## Changes

- Extended the existing minimal interactive compatibility consumer with Drawer, Popover, Tooltip, stable test hooks, and an observed-renderer marker.
- Added drawer content that supports explicit close and navigation/disposal validation.
- Updated `docs/compatibility/hosting-and-render-modes.md` with exact environment, commands, reproduction steps, expected/actual results, console/server findings, status vocabulary, matrix results, and limitations.
- Updated `.bluent/PROJECT.md` and `.bluent/HANDOFF.md`.

## Validation actually run

- `dotnet tool restore` — passed
- `python3 scripts/quality/check_markdown_links.py` — passed across 36 Markdown files, including a final rerun after tracking edits
- `dotnet restore Bluent.sln` — passed
- `dotnet build Bluent.sln --configuration Release --no-restore -warnaserror` — passed, 0 warnings and 0 errors
- `dotnet test Bluent.sln --configuration Release --no-build` — passed, 19/19
- `git diff --check origin/Dev` — passed, including a final rerun
- Focused Release host build — passed, 0 warnings and 0 errors
- Runtime browser validation — passed as detailed above

Closes #387
Closes #388