### PR TITLE
Add canonical compiled task examples

### DIFF
--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -4,18 +4,22 @@ This file is the operational entry point for continuing Bluent with Codex or ano
 
 ## Current Objective
 
-Finalize the approved stable `1.0.367` release candidate through the protected
-artifact-only workflow, tracked in
-[Issue #381](https://github.com/vrassouli/Bluent/issues/381).
+Complete the canonical task-oriented examples and compilation gate tracked in
+[Issue #391](https://github.com/vrassouli/Bluent/issues/391) and
+[Issue #392](https://github.com/vrassouli/Bluent/issues/392).
 
-The preparation must not publish packages or create a tag or GitHub Release.
+This work does not publish packages, create a tag or GitHub Release, add public
+APIs, or include the reference application and benchmark issues.
 
 ## Current Branch and Tracking
 
 - Base branch: `Dev`
-- Active branch: `release/1.0.367`
-- Release issue: [#381](https://github.com/vrassouli/Bluent/issues/381)
-- Final release pull request: pending
+- Active branch: `Dev`
+- Example issues: [#391](https://github.com/vrassouli/Bluent/issues/391) and
+  [#392](https://github.com/vrassouli/Bluent/issues/392)
+- Sprint 4 plan: `.bluent/sprints/sprint-04.md`
+- Pull request: pending
+- Related release issue: [#381](https://github.com/vrassouli/Bluent/issues/381)
 - Preparation issue:
   [#379](https://github.com/vrassouli/Bluent/issues/379) — completed
 - Preparation pull request:
@@ -33,7 +37,7 @@ The preparation must not publish packages or create a tag or GitHub Release.
 1. `AGENTS.md`
 2. `.bluent/PROJECT.md`
 3. this file
-4. `.bluent/sprints/sprint-03.md`
+4. `.bluent/sprints/sprint-04.md`
 5. `.bluent/QUALITY.md`
 6. `.bluent/BACKLOG.md`
 7. `RELEASING.md`
@@ -59,6 +63,22 @@ Merged through PR #377:
 - contributor-ready Issues #374, #375, and #376.
 
 No real tag, GitHub Release, or NuGet publication was created during Sprint 3.
+
+## Active Work State
+
+- A standalone `samples/Bluent.TaskExamples` WebAssembly consumer contains ten
+  task-oriented examples and does not reference the demo projects.
+- Canonical pages under `docs/examples/tasks` link directly to the compiled
+  source and cover package, namespace, setup, assets, behavior, mistakes,
+  render modes, and evidence.
+- Quality CI now runs `scripts/quality/check_task_examples.sh`.
+- The focused validator builds all examples and proves drift detection with an
+  opt-in invalid source whose compiler failure must name the source file.
+- Local validation passed: focused validator, 48-file Markdown link check,
+  tool/solution restore, zero-warning Release build, 19 application tests, 13
+  release-tool tests, workflow YAML parsing, and `git diff --check`.
+- Runtime, visual, deployment, package, and external CI results are not
+  claimed.
 
 ## Current Release State
 
@@ -101,17 +121,14 @@ Before any production publication, the maintainer still must:
 ## Deferred Work
 
 - Issues [#387](https://github.com/vrassouli/Bluent/issues/387) and
-  [#388](https://github.com/vrassouli/Bluent/issues/388) have runtime-complete
-  follow-up work on `test/render-mode-followups`, based on `Dev` commit
-  `782ddad1f082ead94d020e03e95a4c803d4bbbb9`. The probe source exercised at
-  runtime is commit `848a083e4341b26fbf4d394ffea123157b03aa6c`.
-  [PR #389](https://github.com/vrassouli/Bluent/pull/389) is open and
-  non-draft against `Dev`.
+  [#388](https://github.com/vrassouli/Bluent/issues/388) were completed by
+  merged [PR #389](https://github.com/vrassouli/Bluent/pull/389).
 - Issue #366 remains open only for work not covered by those focused issues,
   including exact Interactive Auto renderer-transition timing if the
   maintainer still requires instrumentation.
-- Issue #363 remains separate AI-readiness work.
-- Community outreach, new public components, and Sprint 4 have not started.
+- Issue #363 remains the parent AI-readiness work.
+- Sprint 4 Issues #393 and #394 remain separate from the active examples and
+  compilation workstream.
 
 ## Constraints
 
@@ -124,8 +141,9 @@ Before any production publication, the maintainer still must:
 
 ## Next Session
 
-1. Complete local validation of the exact `1.0.367` candidate.
-2. Run `Release packages` with `publish: false` from the exact candidate commit.
-3. Inspect and record the `bluent-1.0.367` artifact.
-4. Open the final release pull request targeting `Dev` and leave it open for
-   maintainer review.
+1. Review the focused diff and create a branch/commit when requested.
+2. Open a pull request targeting `Dev`.
+3. Record the Quality and release-package workflow results without hiding
+   failures or skipped checks.
+4. Close Issues #391 and #392 only after their independent acceptance criteria
+   and required external workflow evidence are satisfied.

--- a/.bluent/HANDOFF.md
+++ b/.bluent/HANDOFF.md
@@ -14,11 +14,11 @@ APIs, or include the reference application and benchmark issues.
 ## Current Branch and Tracking
 
 - Base branch: `Dev`
-- Active branch: `Dev`
+- Active branch: `codex/issues-391-392`
 - Example issues: [#391](https://github.com/vrassouli/Bluent/issues/391) and
   [#392](https://github.com/vrassouli/Bluent/issues/392)
 - Sprint 4 plan: `.bluent/sprints/sprint-04.md`
-- Pull request: pending
+- Pull request: [#395](https://github.com/vrassouli/Bluent/pull/395) — draft
 - Related release issue: [#381](https://github.com/vrassouli/Bluent/issues/381)
 - Preparation issue:
   [#379](https://github.com/vrassouli/Bluent/issues/379) — completed

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -6,16 +6,18 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 
 ## Current Phase
 
-**Phase:** Stable Release Preparation
-**Current Sprint:** None; Sprint 3 is complete
+**Phase:** Reliable Examples and AI Readiness
+**Current Sprint:** Sprint 4 examples and compilation workstream
 **Status:** In progress
-**Working Branch:** `release/1.0.367`
+**Working Branch:** `Dev`
 **Pull Request:** Pending
-**Tracking Issue:** [#381](https://github.com/vrassouli/Bluent/issues/381)
+**Tracking Issues:** [#391](https://github.com/vrassouli/Bluent/issues/391)
+and [#392](https://github.com/vrassouli/Bluent/issues/392)
 
 ## Operational Files
 
 - `.bluent/HANDOFF.md` — immediate continuation instructions for Codex and other coding agents.
+- `.bluent/sprints/sprint-04.md` — active canonical examples and compilation plan.
 - `.bluent/sprints/sprint-03.md` — completed Sprint 3 execution plan and acceptance criteria.
 - `.bluent/QUALITY.md` — validation evidence and completion policy.
 - `.bluent/BACKLOG.md` — current, next, later, and deferred project work.
@@ -226,8 +228,7 @@ Known deferred compatibility work remains tracked in Issue #366, including trans
 
 **Branch:** `test/render-mode-followups`
 
-**Pull Request:** [#389](https://github.com/vrassouli/Bluent/pull/389) — open
-for review
+**Pull Request:** [#389](https://github.com/vrassouli/Bluent/pull/389) — merged
 
 ### Completed on branch
 
@@ -265,7 +266,7 @@ for review
   errors: 0 warnings, 0 errors; and application tests passed 19/19.
 - The diff against `origin/Dev` passed `git diff --check`.
 - The non-draft [PR #389](https://github.com/vrassouli/Bluent/pull/389)
-  targets `Dev` and remains open for review.
+  was merged into `Dev` on 2026-07-26.
 
 ## Stable Release 1.0.367
 
@@ -319,8 +320,59 @@ Release.
 - [ ] Inspect the uploaded `bluent-1.0.367` artifact.
 - [ ] Open the final non-draft release pull request targeting `Dev`.
 
-Community outreach, new product features, and Sprint 4 remain unstarted until
-the final release pull request is reviewed.
+No publication, tag, or GitHub Release action is part of the active Sprint 4
+examples workstream.
+
+## Sprint 4 — Canonical Examples and Compilation
+
+**Tracking:** [Issue #391](https://github.com/vrassouli/Bluent/issues/391) and
+[Issue #392](https://github.com/vrassouli/Bluent/issues/392)
+
+**Branch:** `Dev`
+
+**Detailed plan:** `.bluent/sprints/sprint-04.md`
+
+**Status:** In progress
+
+### Implemented
+
+- [x] Add ten task-oriented examples covering forms, validation, confirmation,
+  feedback, DataGrid paging, navigation/layout, drawers/popovers, Charts,
+  Diagrams, themes, dark mode, and RTL.
+- [x] Back every example with complete source in a standalone WebAssembly
+  consumer that does not reference demo projects.
+- [x] Add the consumer to the solution with current UI, Charts, and Diagrams
+  project references.
+- [x] Add canonical task pages that link to compiled source and explicitly
+  document package, namespace, setup, assets, behavior, mistakes, render modes,
+  and evidence.
+- [x] Add a focused build script and opt-in invalid-source negative control.
+- [x] Integrate the focused validation into Quality CI.
+- [x] Update maintained documentation indexes, `llms.txt`, contributor
+  guidance, and the changelog.
+
+### Remaining
+
+- [x] Complete and record the repository-required local validation.
+- [x] Update Issues #391 and #392 with exact local evidence and pending external
+  validation.
+- [ ] Open a focused pull request when requested.
+
+Issues #393 and #394 remain separate and are not included in this workstream.
+
+### Local validation summary
+
+- Focused task validation passed: the standalone consumer built with 0
+  warnings and 0 errors, while the opt-in invalid source failed with `CS0234`
+  and a diagnostic naming `InvalidTaskExample.cs.invalid`.
+- Markdown links passed across 48 maintained files.
+- Tool restore and solution restore passed.
+- The Release solution build passed with warnings treated as errors: 0
+  warnings and 0 errors.
+- Application tests passed 19/19; release-tool tests passed 13/13.
+- All three workflow YAML files parsed and `git diff --check` passed.
+- Runtime, visual, deployment, package, and external CI validation were not
+  run or claimed.
 
 ## Accepted Decisions
 

--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -9,8 +9,8 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 **Phase:** Reliable Examples and AI Readiness
 **Current Sprint:** Sprint 4 examples and compilation workstream
 **Status:** In progress
-**Working Branch:** `Dev`
-**Pull Request:** Pending
+**Working Branch:** `codex/issues-391-392`
+**Pull Request:** [#395](https://github.com/vrassouli/Bluent/pull/395) — draft
 **Tracking Issues:** [#391](https://github.com/vrassouli/Bluent/issues/391)
 and [#392](https://github.com/vrassouli/Bluent/issues/392)
 
@@ -328,7 +328,9 @@ examples workstream.
 **Tracking:** [Issue #391](https://github.com/vrassouli/Bluent/issues/391) and
 [Issue #392](https://github.com/vrassouli/Bluent/issues/392)
 
-**Branch:** `Dev`
+**Branch:** `codex/issues-391-392`
+
+**Pull Request:** [#395](https://github.com/vrassouli/Bluent/pull/395) — draft
 
 **Detailed plan:** `.bluent/sprints/sprint-04.md`
 
@@ -356,7 +358,7 @@ examples workstream.
 - [x] Complete and record the repository-required local validation.
 - [x] Update Issues #391 and #392 with exact local evidence and pending external
   validation.
-- [ ] Open a focused pull request when requested.
+- [x] Open draft PR #395 targeting `Dev`.
 
 Issues #393 and #394 remain separate and are not included in this workstream.
 

--- a/.bluent/sprints/sprint-04.md
+++ b/.bluent/sprints/sprint-04.md
@@ -3,7 +3,8 @@
 ## Tracking
 
 - **Base branch:** `Dev`
-- **Working branch:** `Dev`
+- **Working branch:** `codex/issues-391-392`
+- **Pull request:** [#395](https://github.com/vrassouli/Bluent/pull/395) — draft
 - **Issues in this workstream:**
   [#391](https://github.com/vrassouli/Bluent/issues/391) and
   [#392](https://github.com/vrassouli/Bluent/issues/392)
@@ -107,5 +108,5 @@ Run on 2026-07-26 on macOS 26.5.2, Apple Silicon, with .NET SDK
 
 No browser interaction, visual review, deployment, package creation, tag,
 release, or external CI run is claimed by this local evidence. Quality and
-release-package workflow results remain pending until a branch is pushed and a
-pull request is opened.
+release-package workflow results remain pending until GitHub Actions completes
+for PR #395.

--- a/.bluent/sprints/sprint-04.md
+++ b/.bluent/sprints/sprint-04.md
@@ -1,0 +1,111 @@
+# Sprint 4 — Canonical Examples and AI Readiness
+
+## Tracking
+
+- **Base branch:** `Dev`
+- **Working branch:** `Dev`
+- **Issues in this workstream:**
+  [#391](https://github.com/vrassouli/Bluent/issues/391) and
+  [#392](https://github.com/vrassouli/Bluent/issues/392)
+- **Status:** In progress
+- **Started:** 2026-07-26
+
+Issues #393 and #394 are related Sprint 4 work but are not silently included
+in this workstream.
+
+## Objective
+
+Publish at least ten reusable task-oriented examples and make their runnable
+source a durable compiler-validated quality gate.
+
+## Scope
+
+1. Add complete examples for inputs, validation, confirmation, feedback,
+   data-grid operations, navigation/layout, drawers/popovers, charts, diagrams,
+   themes, dark mode, and RTL.
+2. Keep each example in a standalone consumer rather than relying on demo-only
+   imports, registration, services, or assets.
+3. Link documentation directly to the compiled source rather than maintaining
+   divergent Markdown copies.
+4. Build the consumer in normal Quality CI.
+5. Demonstrate that an intentionally invalid API reference fails with a
+   diagnostic identifying the affected source.
+6. Document the contributor workflow and update maintained indexes.
+
+## Non-goals
+
+- New Bluent product components or public APIs.
+- Redesigning the demo.
+- Completing the reference application in Issue #393.
+- Re-running the AI benchmark in Issue #394.
+- Publishing packages, tags, or releases.
+- Claiming runtime or visual evidence from compilation alone.
+
+## Workstreams
+
+### Canonical task sources
+
+- [x] Add a clean standalone Blazor WebAssembly consumer.
+- [x] Add current project references for `Bluent.UI`,
+  `Bluent.UI.Charts`, and `Bluent.UI.Diagrams`.
+- [x] Include explicit imports, `AddBluentUI()`, shared containers, and static
+  assets.
+- [x] Add ten focused task sources with complete Razor/C#.
+
+### Documentation
+
+- [x] Add a predictable task index under `docs/examples/tasks`.
+- [x] Document packages, namespaces, registration, assets, expected behavior,
+  common mistakes, render-mode notes, and evidence for every task.
+- [x] Link each page to its canonical compiled source.
+- [x] Update the documentation index, examples index, contributor guide, and
+  `llms.txt`.
+
+### Validation
+
+- [x] Add the task consumer to `Bluent.sln`.
+- [x] Add a focused validation script that builds with warnings as errors.
+- [x] Add an opt-in invalid source as a negative control.
+- [x] Integrate task validation into the Quality workflow.
+- [x] Run tool restore and solution restore.
+- [x] Run the focused task-example validation.
+- [x] Run Markdown link validation.
+- [x] Run the Release solution build with zero warnings.
+- [x] Run all tests without rebuilding.
+- [x] Parse workflow YAML and run `git diff --check`.
+
+## Acceptance criteria
+
+- All Issue #391 and #392 acceptance criteria are satisfied independently.
+- Every runnable task page links to complete source compiled in normal CI.
+- The consumer does not reference demo projects.
+- Validation output names the deliberately invalid source.
+- Documentation distinguishes source/build evidence from runtime evidence.
+- Project tracking and the two issues accurately report completed and skipped
+  validation.
+
+## Local validation evidence
+
+Run on 2026-07-26 on macOS 26.5.2, Apple Silicon, with .NET SDK
+`10.0.300`:
+
+- `dotnet tool restore` — passed.
+- `dotnet restore Bluent.sln` — passed; all projects were up to date.
+- `bash scripts/quality/check_task_examples.sh` — passed. The valid consumer
+  built with 0 warnings and 0 errors. The negative control failed as required
+  with `CS0234` and named
+  `Validation/InvalidTaskExample.cs.invalid`.
+- `python3 scripts/quality/check_markdown_links.py` — passed across 48
+  Markdown files.
+- `dotnet build Bluent.sln --configuration Release --no-restore -warnaserror`
+  — passed with 0 warnings and 0 errors.
+- `dotnet test Bluent.sln --configuration Release --no-build` — passed 19/19.
+- `python3 -m unittest -v scripts/release/test_release_tools.py` — passed
+  13/13.
+- All three workflow YAML files parsed successfully.
+- `git diff --check` — passed.
+
+No browser interaction, visual review, deployment, package creation, tag,
+release, or external CI run is claimed by this local evidence. Quality and
+release-package workflow results remain pending until a branch is pushed and a
+pull request is opened.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,6 +43,9 @@ jobs:
           --no-restore
           -warnaserror
 
+      - name: Compile canonical task examples and exercise drift detection
+        run: bash scripts/quality/check_task_examples.sh
+
       - name: Test solution
         run: dotnet test Bluent.sln --configuration Release --no-build
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# macOS Finder metadata
+.DS_Store
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/Bluent.sln
+++ b/Bluent.sln
@@ -37,6 +37,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utilities", "Utilities", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bluent.UI.Utilities", "src\Bluent.UI.Utilities\Bluent.UI.Utilities.csproj", "{896C13B8-45B1-4EFC-BD5F-90B4D163B4AC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{D0A60F96-CA00-4986-98CF-74BB39586AE4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bluent.TaskExamples", "samples\Bluent.TaskExamples\Bluent.TaskExamples.csproj", "{07249A7F-A9B5-448B-BFAE-82EB04EBDAB5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +87,10 @@ Global
 		{896C13B8-45B1-4EFC-BD5F-90B4D163B4AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{896C13B8-45B1-4EFC-BD5F-90B4D163B4AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{896C13B8-45B1-4EFC-BD5F-90B4D163B4AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07249A7F-A9B5-448B-BFAE-82EB04EBDAB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07249A7F-A9B5-448B-BFAE-82EB04EBDAB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07249A7F-A9B5-448B-BFAE-82EB04EBDAB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07249A7F-A9B5-448B-BFAE-82EB04EBDAB5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,6 +110,8 @@ Global
 		{19CB01BC-A140-4A21-B496-3BE0BC963805} = {C80130C6-5557-40EB-AE1A-BB56A3851B12}
 		{4ECD1B18-5242-41B5-B386-83D758886A8E} = {C80130C6-5557-40EB-AE1A-BB56A3851B12}
 		{896C13B8-45B1-4EFC-BD5F-90B4D163B4AC} = {4ECD1B18-5242-41B5-B386-83D758886A8E}
+		{D0A60F96-CA00-4986-98CF-74BB39586AE4} = {69D866AC-8961-4961-9629-436E578826D1}
+		{07249A7F-A9B5-448B-BFAE-82EB04EBDAB5} = {D0A60F96-CA00-4986-98CF-74BB39586AE4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC38CD96-1310-46A8-9A5D-36F9AF85D67B}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ for example `[Bluent.UI.Charts]`. Breaking changes must start with
 
 ### Added
 
-- None.
+- Ten canonical, task-oriented Bluent examples backed by a standalone
+  compilable WebAssembly consumer.
+- CI validation that builds documentation examples and proves invalid sample
+  references produce a focused compiler failure.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,24 @@ Run the current test projects with:
 dotnet test Bluent.sln
 ```
 
+### Canonical task examples
+
+Task-oriented documentation uses a standalone WebAssembly consumer so Razor,
+C# models, package references, imports, component parameters, and events are
+compiled rather than maintained as unchecked Markdown snippets.
+
+Run its validation after changing a task example or a public API used by one:
+
+```bash
+bash scripts/quality/check_task_examples.sh
+```
+
+The script first builds every canonical example with warnings treated as
+errors. It then enables an intentionally invalid opt-in source and requires the
+compiler diagnostic to identify that source. Add complete examples under
+`samples/Bluent.TaskExamples`, link them from `docs/examples/tasks`, and do not
+copy a second divergent version into Markdown.
+
 ### Demo
 
 The repository contains WebAssembly and server-rendered demo projects. For the WebAssembly demo:
@@ -111,6 +129,7 @@ Before opening a pull request:
 
 - [ ] Build the solution in Release configuration without compiler warnings.
 - [ ] Run applicable tests.
+- [ ] Compile canonical task examples when their APIs or documentation are affected.
 - [ ] Run `python3 scripts/quality/check_markdown_links.py` for documentation
   changes.
 - [ ] Pack and inspect affected packages for package or release changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ The repository root README remains the short evaluation and installation entry p
 | Components | [`components/`](components/README.md) | Use public components through a consistent reference format |
 | Guides | [`guides/`](guides/theming-localization-rtl-and-assets.md) | Complete cross-component tasks such as forms, dialogs, theming, RTL, and localization |
 | Compatibility | [`compatibility/`](compatibility/README.md) | Check framework, render-mode, package-version, migration, and upgrade guidance |
-| Examples | [`examples/`](examples/README.md) | Find runnable, source-verified examples and reference applications |
+| Examples | [`examples/`](examples/README.md) and [`examples/tasks/`](examples/tasks/README.md) | Find compilable task patterns, runnable examples, and reference applications |
 | Demo gallery | [`demo/`](demo/README.md) | Review current screenshots captured from the validated running demo |
 | AI readiness | [`ai/`](ai/benchmark.md) | Maintain benchmark prompts, dated results, scoring, and recurring failure analysis |
 | Quality | [`quality/compiler-warning-baseline.md`](quality/compiler-warning-baseline.md) | Review the accepted compiler-warning baseline and regression policy |

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,20 @@
 # Runnable examples
 
-The repository's demo projects are the canonical runnable example host:
+## Canonical task examples
+
+The [task-oriented example index](tasks/README.md) contains ten complete
+business-application patterns for inputs, validation, confirmation, feedback,
+data presentation, navigation, overlays, charts, diagrams, theming, and RTL.
+
+Their source lives in the standalone `Bluent.TaskExamples` WebAssembly
+consumer. Quality CI compiles that project and exercises a negative control so
+invalid API references produce a focused failure. The task documentation links
+to the compiled source rather than maintaining duplicate snippets.
+
+## Demo examples
+
+The repository's demo projects remain the broader component-gallery and
+scenario hosts:
 
 - `Bluent.UI.Demo` — Blazor WebAssembly host
 - `Bluent.UI.Demo.SSR` — Blazor Web App/static SSR host
@@ -38,4 +52,7 @@ A demo page counts as:
 
 ## Validation
 
-The Sprint 1 workflow restores and builds the entire solution in Release configuration, runs tests, packs all five libraries, checks local documentation links, and uploads package artifacts.
+The durable Quality workflow restores and builds the entire solution in
+Release configuration, compiles the canonical task consumer, demonstrates
+invalid-sample rejection, runs tests, packs all five libraries, checks local
+documentation links, and uploads package artifacts.

--- a/docs/examples/tasks/README.md
+++ b/docs/examples/tasks/README.md
@@ -1,0 +1,99 @@
+# Canonical task-oriented examples
+
+These examples are complete Blazor WebAssembly tasks backed by the standalone
+[`Bluent.TaskExamples`](../../../samples/Bluent.TaskExamples/) consumer. The
+documentation links to the compiled source instead of copying it into Markdown,
+so a code change cannot leave a second snippet silently out of date.
+
+## Task index
+
+| Task | Packages | Canonical source |
+| --- | --- | --- |
+| [Basic form input](basic-input.md) | `Bluent.UI` | [`BasicInput.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/BasicInput.razor) |
+| [Form validation](form-validation.md) | `Bluent.UI` | [`FormValidation.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/FormValidation.razor) |
+| [Confirmation dialog](confirmation-dialog.md) | `Bluent.UI` | [`ConfirmationDialog.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/ConfirmationDialog.razor) |
+| [Toast and MessageBar feedback](feedback.md) | `Bluent.UI` | [`Feedback.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/Feedback.razor) |
+| [DataGrid with paging](data-grid-paging.md) | `Bluent.UI` | [`DataGridPaging.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/DataGridPaging.razor) |
+| [Navigation and layout](navigation-and-layout.md) | `Bluent.UI` | [`NavigationAndLayout.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/NavigationAndLayout.razor) |
+| [Drawer and Popover](drawer-and-popover.md) | `Bluent.UI` | [`DrawerAndPopover.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/DrawerAndPopover.razor) |
+| [Chart dashboard](chart-dashboard.md) | `Bluent.UI`, `Bluent.UI.Charts` | [`ChartDashboard.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/ChartDashboard.razor) |
+| [Simple diagram](simple-diagram.md) | `Bluent.UI.Diagrams` | [`SimpleDiagram.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/SimpleDiagram.razor) |
+| [Theme, dark mode, and RTL](theme-dark-mode-and-rtl.md) | `Bluent.UI` | [`ThemeAndRtl.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/ThemeAndRtl.razor) |
+
+## Shared consumer setup
+
+The consumer project uses project references so every change is compiled
+against the current repository source. A normal application installs the
+matching released packages instead:
+
+```bash
+dotnet add package Bluent.UI
+dotnet add package Bluent.UI.Charts
+dotnet add package Bluent.UI.Diagrams
+```
+
+The main UI package does not transitively install Charts or Diagrams. Charts
+and Diagrams do not transitively install the main UI package. Prefer aligned
+versions for every directly installed Bluent package.
+
+The consumer's [`_Imports.razor`](../../../samples/Bluent.TaskExamples/_Imports.razor)
+contains the public component namespaces:
+
+- `Bluent.UI.Components`
+- `Bluent.UI.Charts.Components`
+- `Bluent.UI.Diagrams.Components`
+
+Its [`Program.cs`](../../../samples/Bluent.TaskExamples/Program.cs) calls
+`builder.Services.AddBluentUI()`. The
+[`MainLayout.razor`](../../../samples/Bluent.TaskExamples/Layout/MainLayout.razor)
+contains one `<Containers />` for service-backed overlays. The
+[`index.html`](../../../samples/Bluent.TaskExamples/wwwroot/index.html) loads:
+
+```html
+<link href="_content/Bluent.UI/bluent.ui.theme.default.min.css" rel="stylesheet" />
+<link href="_content/Bluent.UI/bluent.ui.components.min.css" rel="stylesheet" />
+<link href="_content/Bluent.UI.Diagrams/bluent.ui.diagrams.min.css" rel="stylesheet" />
+```
+
+The base package loads its ES module through JavaScript interop. Do not add a
+global base-package script tag. The chart package also manages its packaged
+JavaScript through its component lifecycle.
+
+## Run the examples
+
+From the repository root:
+
+```bash
+dotnet run --project samples/Bluent.TaskExamples/Bluent.TaskExamples.csproj
+```
+
+This is a standalone consumer and does not inherit registration, imports,
+containers, or assets from either demo host.
+
+## Compilation and drift protection
+
+Quality CI runs
+[`check_task_examples.sh`](../../../scripts/quality/check_task_examples.sh).
+The script builds the entire consumer with warnings treated as errors. It then
+enables an intentionally invalid opt-in source and requires compilation to
+fail with a diagnostic naming that source. This negative control demonstrates
+that an invalid component/API reference is detected rather than silently
+ignored.
+
+When adding an example:
+
+1. Put its complete runnable source under `samples/Bluent.TaskExamples`.
+2. Link that source from its task page; do not copy a divergent code block.
+3. Add its route to the sample navigation.
+4. Build the sample project and run the task-example validation script.
+5. Run the repository Markdown link check, Release build, and tests.
+
+## Evidence and limitations
+
+The sources were checked against current `Dev` APIs and build as one standalone
+Blazor WebAssembly application. Compilation verifies Razor, C#, project
+references, imports, component names, parameters, events, registration code,
+and static-asset paths present in the source. It does not by itself prove every
+interactive browser behavior or every render mode. Use the
+[hosting and render-mode evidence](../../compatibility/hosting-and-render-modes.md)
+for runtime-qualified claims.

--- a/docs/examples/tasks/basic-input.md
+++ b/docs/examples/tasks/basic-input.md
@@ -1,0 +1,37 @@
+# Basic form input
+
+Use this pattern for ordinary bound text, numeric, select, and Boolean inputs.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespace: `Bluent.UI.Components`
+- Services: `builder.Services.AddBluentUI()`
+- Assets: both base `Bluent.UI` stylesheets from the [shared setup](README.md#shared-consumer-setup)
+
+## Complete source
+
+[`BasicInput.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/BasicInput.razor)
+is the canonical compiled source. It binds `TextField`, `NumericField`,
+`SelectField`, and `Checkbox` values and displays the current model state.
+
+## Expected behavior
+
+Typing a name updates the status as input occurs. The numeric field enforces
+the declared minimum and maximum in its UI, the select changes the role, and
+the checkbox changes the update preference.
+
+## Common mistakes
+
+- Import `Bluent.UI.Components`, not `Bluent.UI`.
+- Use `@bind-Value`; do not assume every component binds through the native
+  HTML `value` attribute.
+- `BindValueEvent="oninput"` is explicit when immediate text updates matter.
+- Application validation must still enforce business rules; HTML bounds alone
+  are not a server-side validation strategy.
+
+## Render modes and evidence
+
+The source is build-verified in the standalone WebAssembly consumer. Binding
+and callbacks require an interactive render mode. Static SSR can render the
+initial markup but cannot update the model.

--- a/docs/examples/tasks/chart-dashboard.md
+++ b/docs/examples/tasks/chart-dashboard.md
@@ -1,0 +1,40 @@
+# Dashboard using Bluent.UI.Charts
+
+Use the Charts package for a compact operational visualization and keep the
+dataset typed in application code.
+
+## Requirements
+
+- Packages: `Bluent.UI.Charts`; `Bluent.UI` only when the page also uses main
+  UI components such as `MessageBar`
+- Namespaces: `Bluent.UI.Charts.Components` and
+  `Bluent.UI.Charts.ChartJs`
+- Assets: the main UI styles when using main components; no manually added
+  global Chart.js script is required by this verified pattern
+
+## Complete source
+
+[`ChartDashboard.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/ChartDashboard.razor)
+is the canonical compiled source. It contains the chart, legend, title, axis,
+line dataset, colors, fill, and typed throughput data.
+
+## Expected behavior
+
+The chart renders one smooth line/area series with weekday labels and a hidden
+legend. The surrounding MessageBar provides a textual context rather than
+using the chart as the only explanation.
+
+## Common mistakes
+
+- Installing `Bluent.UI` does not install `Bluent.UI.Charts`.
+- Import the Charts component and Chart.js option namespaces.
+- Do not add an unverified global script tag; the component uses its packaged
+  module lifecycle.
+- Provide an accessible textual summary when the data is important.
+
+## Render modes and evidence
+
+The chart source and package relationship are build-verified. Canvas
+initialization requires an interactive browser. Representative chart runtime
+evidence exists for WebAssembly and the interactive Blazor Web App modes in
+the [hosting guide](../../compatibility/hosting-and-render-modes.md).

--- a/docs/examples/tasks/confirmation-dialog.md
+++ b/docs/examples/tasks/confirmation-dialog.md
@@ -1,0 +1,38 @@
+# Confirmation dialog
+
+Use a modal confirmation before a consequential action, and change state only
+when the returned result is affirmative.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespaces: `Bluent.UI.Components` and `Bluent.UI.Services.Abstractions`
+- Services: `builder.Services.AddBluentUI()`
+- Layout: one `<Containers />` in the same interactive service scope
+- Assets: both base stylesheets from the [shared setup](README.md#shared-consumer-setup)
+
+## Complete source
+
+[`ConfirmationDialog.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/ConfirmationDialog.razor)
+is the canonical compiled source. It injects `IDialogService`, awaits
+`ShowMessageBoxAsync`, and checks for `MessageBoxResult.Yes`.
+
+## Expected behavior
+
+The action opens a Yes/Cancel dialog. Yes archives the request; cancel or
+dismissal leaves it active and reports that outcome.
+
+## Common mistakes
+
+- Do not mutate state before awaiting the result.
+- Do not compare a message-box result with an unrelated Boolean or string.
+- Missing `AddBluentUI()` or `<Containers />` prevents the service-backed
+  overlay from working.
+- Put the container in the same interactive scope as the caller.
+
+## Render modes and evidence
+
+The source is build-verified in WebAssembly. Dialog display and result handling
+require interactivity. Representative dialog service behavior has runtime
+evidence in the modes listed by the
+[hosting guide](../../compatibility/hosting-and-render-modes.md).

--- a/docs/examples/tasks/data-grid-paging.md
+++ b/docs/examples/tasks/data-grid-paging.md
@@ -1,0 +1,38 @@
+# DataGrid with paging
+
+Use `DataGrid` with an `ItemsProvider` for row virtualization and `DataPager`
+for application-controlled pages.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespaces: `Bluent.UI.Components` and
+  `Microsoft.AspNetCore.Components.Web.Virtualization`
+- Services and assets: the [shared setup](README.md#shared-consumer-setup)
+
+## Complete source
+
+[`DataGridPaging.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/DataGridPaging.razor)
+is the canonical compiled source. It contains the row model, in-memory data
+source, `ItemsProvider`, page calculation, columns, custom currency cell, and
+bound pager.
+
+## Expected behavior
+
+The grid displays five orders per application page. Pager actions change the
+page, recreate the keyed grid, and request the corresponding slice of rows.
+
+## Common mistakes
+
+- `ItemsProviderRequest.StartIndex` and `Count` describe the grid's requested
+  range; honor both values.
+- Return the count for the current provider result set, not an invented total.
+- Production sorting, filtering, paging, authorization, and cancellation
+  remain data-source responsibilities.
+- Give the grid a constrained height so virtualization has a usable viewport.
+
+## Render modes and evidence
+
+The generic row type, provider delegate, columns, pager parameters, and model
+compile in the WebAssembly consumer. Virtualization, paging callbacks, and
+JavaScript-backed grid behavior require an interactive browser context.

--- a/docs/examples/tasks/drawer-and-popover.md
+++ b/docs/examples/tasks/drawer-and-popover.md
@@ -1,0 +1,43 @@
+# Drawer and Popover interaction
+
+Use a drawer for a larger secondary workflow and a popover for compact content
+anchored to a trigger.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespaces: `Bluent.UI.Components`,
+  `Bluent.UI.Components.DrawerComponent`, and
+  `Bluent.UI.Services.Abstractions`
+- Services: `builder.Services.AddBluentUI()`
+- Layout: one `<Containers />` in the active interactive scope
+- Assets: both base stylesheets from the [shared setup](README.md#shared-consumer-setup)
+
+## Complete source
+
+- [`DrawerAndPopover.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/DrawerAndPopover.razor)
+  opens the service-backed drawer and declares an anchored popover.
+- [`DrawerTaskContent.razor`](../../../samples/Bluent.TaskExamples/Shared/DrawerTaskContent.razor)
+  consumes the cascading `Drawer` and closes it with a result.
+
+## Expected behavior
+
+The primary action opens an end-positioned drawer. Apply returns the selected
+filter state; cancel or dismissal returns no result. The popover appears below
+its trigger and matches the trigger width.
+
+## Common mistakes
+
+- Drawer content closes the cascading `Drawer`; it does not create another
+  drawer service request.
+- Use logical start/end placement for direction-aware layouts.
+- Missing registration, containers, or interactivity prevents overlays from
+  working.
+- Do not assume static SSR supports placement, dismissal, or focus behavior.
+
+## Render modes and evidence
+
+Both Razor files and the generic service overload are build-verified.
+Representative drawer disposal and Popover measurement have runtime evidence
+in the interactive modes listed by the
+[hosting guide](../../compatibility/hosting-and-render-modes.md).

--- a/docs/examples/tasks/feedback.md
+++ b/docs/examples/tasks/feedback.md
@@ -1,0 +1,37 @@
+# Toast and MessageBar feedback
+
+Use `MessageBar` for feedback that belongs in the page flow and
+`IToastService` for short-lived global feedback.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespaces: `Bluent.UI.Components` and `Bluent.UI.Services.Abstractions`
+- Services: `builder.Services.AddBluentUI()`
+- Layout: one `<Containers />` for toasts
+- Assets: both base stylesheets from the [shared setup](README.md#shared-consumer-setup)
+
+## Complete source
+
+[`Feedback.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/Feedback.razor)
+is the canonical compiled source. It combines a persistent `MessageBar` with a
+success toast configured for the bottom-end placement.
+
+## Expected behavior
+
+Saving changes updates the inline message and opens a transient success toast.
+Resetting returns the inline guidance to its initial state.
+
+## Common mistakes
+
+- Do not use a toast as the only durable record of an important failure.
+- `IToastService` requires registration and the shared container.
+- Do not fire service calls from a static SSR-only component and expect browser
+  interaction.
+- Toast placement is logical (`BottomEnd`) and responds to document direction.
+
+## Render modes and evidence
+
+The source is build-verified in WebAssembly. Toasts and button callbacks
+require interactivity; the initial MessageBar can produce display-only markup
+in static SSR.

--- a/docs/examples/tasks/form-validation.md
+++ b/docs/examples/tasks/form-validation.md
@@ -1,0 +1,38 @@
+# Form validation
+
+Use Bluent fields inside the standard Blazor `EditForm` and validation system.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespaces: `Bluent.UI.Components`,
+  `Microsoft.AspNetCore.Components.Forms`, and
+  `System.ComponentModel.DataAnnotations`
+- Services and assets: the [shared setup](README.md#shared-consumer-setup)
+
+## Complete source
+
+[`FormValidation.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/FormValidation.razor)
+is the canonical compiled source. It includes the complete model,
+data-annotation rules, `DataAnnotationsValidator`, validation messages, and
+valid-submit handler.
+
+## Expected behavior
+
+Submitting empty or invalid values displays validation messages. The success
+MessageBar appears only after the form passes validation.
+
+## Common mistakes
+
+- Add `DataAnnotationsValidator`; annotations on the model are not sufficient
+  by themselves.
+- Bind validation messages to the same model properties as the fields.
+- Use `type="submit"` for the submit button and `OnValidSubmit` when invalid
+  submissions must not run the save handler.
+- Do not present uncompiled pseudocode as a form example.
+
+## Render modes and evidence
+
+The Razor page and model are build-verified in WebAssembly. Validation events
+and submit callbacks require interactivity. The pattern uses Blazor's standard
+forms APIs and does not imply a persistence or server-validation mechanism.

--- a/docs/examples/tasks/navigation-and-layout.md
+++ b/docs/examples/tasks/navigation-and-layout.md
@@ -1,0 +1,44 @@
+# Navigation and layout
+
+Keep application navigation in a shared layout and host Bluent overlay
+containers once for the rendered layout tree.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespaces: `Bluent.UI.Components`,
+  `Microsoft.AspNetCore.Components`, and
+  `Microsoft.AspNetCore.Components.Routing`
+- Services and assets: the [shared setup](README.md#shared-consumer-setup)
+
+## Complete source
+
+- [`MainLayout.razor`](../../../samples/Bluent.TaskExamples/Layout/MainLayout.razor)
+  owns navigation, page content, and `<Containers />`.
+- [`NavigationAndLayout.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/NavigationAndLayout.razor)
+  uses `NavLink` and `NavigationManager`.
+- [`App.razor`](../../../samples/Bluent.TaskExamples/App.razor) assigns the
+  layout through `RouteView`.
+
+Together these files are the complete compiled navigation pattern.
+
+## Expected behavior
+
+Route links update the main content without duplicating layout markup.
+`NavLink` applies active-state semantics, and programmatic navigation returns
+to the overview.
+
+## Common mistakes
+
+- Do not add a separate `<Containers />` to every page.
+- Avoid hard-coding deployment base paths into internal navigation.
+- Use `NavLink` when active-route semantics matter and
+  `NavigationManager.NavigateTo` for programmatic navigation.
+- Responsive navigation behavior is application layout work, not an implicit
+  feature of the router.
+
+## Render modes and evidence
+
+The router, layout, links, and navigation callback are build-verified in the
+standalone WebAssembly app. Static SSR can render links and layout markup;
+client-side callbacks require interactivity.

--- a/docs/examples/tasks/simple-diagram.md
+++ b/docs/examples/tasks/simple-diagram.md
@@ -1,0 +1,40 @@
+# Simple diagram using Bluent.UI.Diagrams
+
+Use the Diagrams package when an application needs a diagram surface. This
+minimal example supplies meaningful SVG child content without introducing an
+editor workflow.
+
+## Requirements
+
+- Package: `Bluent.UI.Diagrams`
+- Namespace: `Bluent.UI.Diagrams.Components`
+- Stylesheet:
+  `_content/Bluent.UI.Diagrams/bluent.ui.diagrams.min.css`
+- `Bluent.UI` is separate and is not installed transitively by Diagrams
+
+## Complete source
+
+[`SimpleDiagram.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/SimpleDiagram.razor)
+is the canonical compiled source. It declares a `Diagram` with two labeled
+states and a directional connector using SVG child content.
+
+## Expected behavior
+
+The package surface renders a new-order state connected to a fulfilled state
+inside a constrained diagram frame.
+
+## Common mistakes
+
+- Installing `Bluent.UI` does not install `Bluent.UI.Diagrams`.
+- Include the diagram stylesheet in addition to any main UI styles.
+- Constrain the diagram's height; an unconstrained canvas may have no useful
+  visible area.
+- This example is a display diagram, not proof of editing, selection, keyboard,
+  touch, or persistence behavior.
+
+## Render modes and evidence
+
+The package, component, and child SVG compile in the standalone consumer.
+Diagram module initialization requires an interactive browser. Representative
+runtime evidence is recorded in the
+[hosting guide](../../compatibility/hosting-and-render-modes.md).

--- a/docs/examples/tasks/theme-dark-mode-and-rtl.md
+++ b/docs/examples/tasks/theme-dark-mode-and-rtl.md
@@ -1,0 +1,44 @@
+# Theme, dark mode, and RTL
+
+Use `IBluentTheme` to change the active theme family, light/dark mode, and
+document direction after the application becomes interactive.
+
+## Requirements
+
+- Package: `Bluent.UI`
+- Namespaces: `Bluent.UI.Components` and
+  `Bluent.UI.Interops.Abstractions`
+- Services: `builder.Services.AddBluentUI()`
+- Initial document attributes: `data-bui-theme="light"` and `dir="ltr"` (or
+  the application's chosen initial values)
+- Assets: exactly one packaged theme stylesheet plus the component stylesheet
+
+## Complete source
+
+[`ThemeAndRtl.razor`](../../../samples/Bluent.TaskExamples/Pages/Tasks/ThemeAndRtl.razor)
+is the canonical compiled runtime source. The consumer
+[`index.html`](../../../samples/Bluent.TaskExamples/wwwroot/index.html)
+contains the initial document attributes and stylesheet link.
+
+## Expected behavior
+
+Light/dark actions update `data-bui-theme`. Theme-family actions replace the
+active `bluent.ui.theme.{name}.min.css` link. LTR/RTL actions update the root
+`dir` attribute.
+
+## Common mistakes
+
+- Theme family and light/dark mode are independent settings.
+- Pass only a packaged theme family such as `default` or `teams`.
+- Keep one active link whose filename follows the packaged theme pattern.
+- `IBluentTheme` does not persist preferences; application code must store and
+  reapply them.
+- Apply initial attributes early to reduce a flash of the wrong mode or
+  direction.
+
+## Render modes and evidence
+
+The theme service calls compile in the WebAssembly consumer and the demo has
+runtime visual evidence for light/dark and LTR/RTL. These operations require
+browser interop; static SSR can only use the initial document attributes. See
+the full [theming and RTL guide](../../guides/theming-localization-rtl-and-assets.md).

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,20 @@ Bluent is open source under Apache License 2.0. The current repository targets .
 - [Package selection](https://github.com/vrassouli/Bluent/blob/Dev/docs/packages/index.md): package roles, dependency boundaries, namespaces, and optional setup
 - [Documentation index](https://github.com/vrassouli/Bluent/blob/Dev/docs/README.md): canonical documentation map and source-of-truth rules
 - [Demo gallery](https://github.com/vrassouli/Bluent/blob/Dev/docs/demo/README.md): validated landing, component showcase, enterprise scenario, dark-theme, and RTL screenshots
+- [Canonical task examples](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/README.md): ten complete, compiled patterns for common Bluent application tasks
+
+## Task-oriented examples
+
+- [Basic form input](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/basic-input.md): bound text, numeric, select, and Boolean inputs
+- [Form validation](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/form-validation.md): EditForm, data annotations, validation messages, and valid submit
+- [Confirmation dialog](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/confirmation-dialog.md): awaited modal result before a consequential action
+- [Toast and MessageBar feedback](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/feedback.md): persistent inline and transient global feedback
+- [DataGrid with paging](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/data-grid-paging.md): typed columns, ItemsProvider, and DataPager
+- [Navigation and layout](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/navigation-and-layout.md): Router, shared layout, NavLink, NavigationManager, and one Containers host
+- [Drawer and Popover](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/drawer-and-popover.md): service-backed drawer results and anchored popover content
+- [Chart dashboard](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/chart-dashboard.md): typed Chart.js-backed operational dataset
+- [Simple diagram](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/simple-diagram.md): packaged diagram surface with meaningful SVG content
+- [Theme, dark mode, and RTL](https://github.com/vrassouli/Bluent/blob/Dev/docs/examples/tasks/theme-dark-mode-and-rtl.md): runtime theme family, mode, and direction changes
 
 ## Components
 

--- a/samples/Bluent.TaskExamples/App.razor
+++ b/samples/Bluent.TaskExamples/App.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/samples/Bluent.TaskExamples/Bluent.TaskExamples.csproj
+++ b/samples/Bluent.TaskExamples/Bluent.TaskExamples.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Bluent.UI/Bluent.UI.csproj" />
+    <ProjectReference Include="../../src/Bluent.UI.Charts/Bluent.UI.Charts.csproj" />
+    <ProjectReference Include="../../src/Bluent.UI.Diagrams/Bluent.UI.Diagrams.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(ValidateInvalidTaskExample)' == 'true'">
+    <Compile Include="Validation/InvalidTaskExample.cs.invalid" />
+  </ItemGroup>
+</Project>

--- a/samples/Bluent.TaskExamples/Layout/MainLayout.razor
+++ b/samples/Bluent.TaskExamples/Layout/MainLayout.razor
@@ -1,0 +1,27 @@
+@inherits LayoutComponentBase
+
+<header class="app-header">
+    <a href="">Bluent task examples</a>
+</header>
+
+<div class="app-shell">
+    <nav aria-label="Task examples">
+        <NavLink href="" Match="NavLinkMatch.All">Overview</NavLink>
+        <NavLink href="tasks/basic-input">Basic input</NavLink>
+        <NavLink href="tasks/form-validation">Form validation</NavLink>
+        <NavLink href="tasks/confirmation-dialog">Confirmation dialog</NavLink>
+        <NavLink href="tasks/feedback">Feedback</NavLink>
+        <NavLink href="tasks/data-grid">Data grid</NavLink>
+        <NavLink href="tasks/navigation-layout">Navigation and layout</NavLink>
+        <NavLink href="tasks/drawer-popover">Drawer and popover</NavLink>
+        <NavLink href="tasks/chart-dashboard">Chart dashboard</NavLink>
+        <NavLink href="tasks/simple-diagram">Simple diagram</NavLink>
+        <NavLink href="tasks/theme-rtl">Theme and RTL</NavLink>
+    </nav>
+
+    <main>
+        @Body
+    </main>
+</div>
+
+<Containers />

--- a/samples/Bluent.TaskExamples/Pages/Home.razor
+++ b/samples/Bluent.TaskExamples/Pages/Home.razor
@@ -1,0 +1,10 @@
+@page "/"
+
+<PageTitle>Bluent task examples</PageTitle>
+
+<h1>Bluent task examples</h1>
+
+<MessageBar Type="MessageBarType.Information" Multiline>
+    These ten examples are the canonical compilable sources for the task-oriented
+    documentation. Use the navigation to open a focused example.
+</MessageBar>

--- a/samples/Bluent.TaskExamples/Pages/NotFound.razor
+++ b/samples/Bluent.TaskExamples/Pages/NotFound.razor
@@ -1,0 +1,7 @@
+@page "/not-found"
+@layout MainLayout
+
+<PageTitle>Not found</PageTitle>
+
+<h1>Not found</h1>
+<p>The requested task example does not exist.</p>

--- a/samples/Bluent.TaskExamples/Pages/Tasks/BasicInput.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/BasicInput.razor
@@ -1,0 +1,41 @@
+@page "/tasks/basic-input"
+
+<PageTitle>Basic input</PageTitle>
+
+<h1>Basic form input</h1>
+
+<div class="example-field">
+    <label for="contact-name">Contact name</label>
+    <TextField id="contact-name"
+               @bind-Value="_name"
+               BindValueEvent="oninput"
+               autocomplete="name" />
+</div>
+
+<div class="example-field">
+    <label for="seat-count">Seat count</label>
+    <NumericField id="seat-count" @bind-Value="_seats" Min="1" Max="500" />
+</div>
+
+<div class="example-field">
+    <label for="account-role">Account role</label>
+    <SelectField id="account-role" @bind-Value="_role">
+        <option value="Administrator">Administrator</option>
+        <option value="Billing">Billing</option>
+        <option value="Viewer">Viewer</option>
+    </SelectField>
+</div>
+
+<Checkbox @bind-Value="_sendUpdates" Label="Send product updates" />
+
+<p role="status">
+    @_name will receive @_role access for @_seats seat(s).
+    Product updates: @(_sendUpdates ? "on" : "off").
+</p>
+
+@code {
+    private string _name = "Alex Morgan";
+    private int _seats = 12;
+    private string _role = "Administrator";
+    private bool _sendUpdates = true;
+}

--- a/samples/Bluent.TaskExamples/Pages/Tasks/ChartDashboard.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/ChartDashboard.razor
@@ -1,0 +1,36 @@
+@page "/tasks/chart-dashboard"
+
+<PageTitle>Chart dashboard</PageTitle>
+
+<h1>Dashboard using Bluent.UI.Charts</h1>
+
+<MessageBar Type="MessageBarType.Information">
+    Weekly order throughput
+</MessageBar>
+
+<div style="max-width: 42rem;">
+    <Chart>
+        <Legend Display="false" />
+        <Title Text="Completed orders" />
+        <YScale Text="Orders" />
+        <Dataset ChartType="ChartType.Line"
+                 Data="_throughput"
+                 Label="Completed"
+                 Smooth
+                 FillTarget="FillTarget.Start"
+                 BorderWidth="2"
+                 BorderColor="@DefaultColors.Purple"
+                 BackgroundColor="@DefaultColors.Purple.Opacity(64)" />
+    </Chart>
+</div>
+
+@code {
+    private readonly Dictionary<string, double> _throughput = new()
+    {
+        ["Mon"] = 82,
+        ["Tue"] = 94,
+        ["Wed"] = 91,
+        ["Thu"] = 108,
+        ["Fri"] = 116
+    };
+}

--- a/samples/Bluent.TaskExamples/Pages/Tasks/ConfirmationDialog.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/ConfirmationDialog.razor
@@ -1,0 +1,39 @@
+@page "/tasks/confirmation-dialog"
+@inject IDialogService DialogService
+
+<PageTitle>Confirmation dialog</PageTitle>
+
+<h1>Confirmation dialog</h1>
+
+<p>Archive an expired access request only after explicit confirmation.</p>
+
+<Button Text="Archive request"
+        Appearance="ButtonAppearance.Primary"
+        disabled="@_archived"
+        OnClick="ConfirmArchive" />
+
+<p role="status">@_status</p>
+
+@code {
+    private bool _archived;
+    private string _status = "The request is active.";
+
+    private async Task ConfirmArchive()
+    {
+        var result = await DialogService.ShowMessageBoxAsync(
+            "Archive access request?",
+            "The request will leave the active queue, but its audit history will remain.",
+            MessageBoxButton.Yes | MessageBoxButton.Cancel,
+            MessageBoxButton.Yes);
+
+        if (result == MessageBoxResult.Yes)
+        {
+            _archived = true;
+            _status = "The request was archived.";
+        }
+        else
+        {
+            _status = "Archive canceled; the request is still active.";
+        }
+    }
+}

--- a/samples/Bluent.TaskExamples/Pages/Tasks/DataGridPaging.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/DataGridPaging.razor
@@ -1,0 +1,62 @@
+@page "/tasks/data-grid"
+
+<PageTitle>Data grid with paging</PageTitle>
+
+<h1>DataGrid with paging</h1>
+
+<DataGrid @key="_page"
+          ItemsProvider="LoadOrders"
+          Style="height: 12rem;">
+    <Columns>
+        <DataGridColumn TItem="OrderRow" Field="order => order.Number" Header="Order" Width="120" />
+        <DataGridColumn TItem="OrderRow" Field="order => order.Customer" Width="220" />
+        <DataGridColumn TItem="OrderRow" Field="order => order.Status" Width="140" />
+        <DataGridColumn TItem="OrderRow" Field="order => order.Total" Width="120">
+            @context.Total.ToString("C")
+        </DataGridColumn>
+    </Columns>
+</DataGrid>
+
+<DataPager PageCount="@PageCount"
+           @bind-Page="_page"
+           ShowFirstPage
+           ShowPreviousPage
+           ShowNextPage
+           ShowLastPage />
+
+@code {
+    private const int PageSize = 5;
+    private int _page = 1;
+
+    private readonly IReadOnlyList<OrderRow> _orders =
+        Enumerable.Range(1, 23)
+            .Select(index => new OrderRow(
+                $"SO-{index:0000}",
+                $"Customer {index}",
+                index % 3 == 0 ? "Review" : "Ready",
+                125m + (index * 17.5m)))
+            .ToArray();
+
+    private int PageCount => (int)Math.Ceiling(_orders.Count / (double)PageSize);
+
+    private ValueTask<ItemsProviderResult<OrderRow>> LoadOrders(ItemsProviderRequest request)
+    {
+        var pageItems = _orders
+            .Skip((_page - 1) * PageSize)
+            .Take(PageSize)
+            .ToArray();
+
+        var visibleItems = pageItems
+            .Skip(request.StartIndex)
+            .Take(request.Count);
+
+        return ValueTask.FromResult(
+            new ItemsProviderResult<OrderRow>(visibleItems, pageItems.Length));
+    }
+
+    private sealed record OrderRow(
+        string Number,
+        string Customer,
+        string Status,
+        decimal Total);
+}

--- a/samples/Bluent.TaskExamples/Pages/Tasks/DrawerAndPopover.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/DrawerAndPopover.razor
@@ -1,0 +1,40 @@
+@page "/tasks/drawer-popover"
+@inject IDrawerService DrawerService
+
+<PageTitle>Drawer and popover</PageTitle>
+
+<h1>Drawer and Popover interaction</h1>
+
+<div class="example-actions">
+    <Button Text="Open filter drawer"
+            Appearance="ButtonAppearance.Primary"
+            OnClick="OpenDrawer" />
+
+    <Popover Placement="Placement.BottomStart" SameWidth>
+        <Trigger>
+            <Button Text="Show order summary" />
+        </Trigger>
+        <Surface>
+            <div class="p-3">
+                <strong>18 open orders</strong>
+                <div>3 require review.</div>
+            </div>
+        </Surface>
+    </Popover>
+</div>
+
+<p role="status">Drawer result: @_drawerResult</p>
+
+@code {
+    private string _drawerResult = "Not opened";
+
+    private async Task OpenDrawer()
+    {
+        var result = await DrawerService.ShowAsync<DrawerTaskContent>(
+            "Order filters",
+            null,
+            configuration => configuration.SetPosition(DrawerPosition.End));
+
+        _drawerResult = result?.ToString() ?? "Dismissed";
+    }
+}

--- a/samples/Bluent.TaskExamples/Pages/Tasks/Feedback.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/Feedback.razor
@@ -1,0 +1,41 @@
+@page "/tasks/feedback"
+@inject IToastService ToastService
+
+<PageTitle>Toast and message feedback</PageTitle>
+
+<h1>Toast and MessageBar feedback</h1>
+
+<MessageBar Type="@(_saved ? MessageBarType.Success : MessageBarType.Information)"
+            Multiline
+            Dismissable>
+    @(_saved
+        ? "Changes are saved. This persistent message remains in the workflow."
+        : "Save the record to see persistent and transient feedback together.")
+</MessageBar>
+
+<div class="example-actions">
+    <Button Text="Save record"
+            Appearance="ButtonAppearance.Primary"
+            OnClick="Save" />
+    <Button Text="Reset" OnClick="Reset" />
+</div>
+
+@code {
+    private bool _saved;
+
+    private void Save()
+    {
+        _saved = true;
+        _ = ToastService.ShowAsync(
+            "Record saved",
+            configuration => configuration
+                .SetMessage("The customer record is up to date.")
+                .SetIntend(ToastIntend.Success)
+                .SetPlace(ToastPlacement.BottomEnd));
+    }
+
+    private void Reset()
+    {
+        _saved = false;
+    }
+}

--- a/samples/Bluent.TaskExamples/Pages/Tasks/FormValidation.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/FormValidation.razor
@@ -1,0 +1,54 @@
+@page "/tasks/form-validation"
+
+<PageTitle>Form validation</PageTitle>
+
+<h1>Form validation</h1>
+
+<EditForm Model="_model" OnValidSubmit="Save">
+    <DataAnnotationsValidator />
+
+    <div class="example-field">
+        <label for="customer-name">Customer name</label>
+        <TextField id="customer-name" @bind-Value="_model.Name" autocomplete="name" />
+        <ValidationMessage For="() => _model.Name" />
+    </div>
+
+    <div class="example-field">
+        <label for="customer-email">Work email</label>
+        <TextField id="customer-email"
+                   @bind-Value="_model.Email"
+                   type="email"
+                   autocomplete="email" />
+        <ValidationMessage For="() => _model.Email" />
+    </div>
+
+    <Button type="submit"
+            Text="Save customer"
+            Appearance="ButtonAppearance.Primary" />
+</EditForm>
+
+@if (_saved)
+{
+    <MessageBar Type="MessageBarType.Success" Class="mt-4">
+        Customer saved.
+    </MessageBar>
+}
+
+@code {
+    private readonly CustomerModel _model = new();
+    private bool _saved;
+
+    private void Save()
+    {
+        _saved = true;
+    }
+
+    private sealed class CustomerModel
+    {
+        [Required, StringLength(80, MinimumLength = 2)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required, EmailAddress]
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/samples/Bluent.TaskExamples/Pages/Tasks/NavigationAndLayout.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/NavigationAndLayout.razor
@@ -1,0 +1,21 @@
+@page "/tasks/navigation-layout"
+@inject NavigationManager Navigation
+
+<PageTitle>Navigation and layout</PageTitle>
+
+<h1>Navigation and layout</h1>
+
+<p>
+    This page is rendered by <code>MainLayout</code>. The layout owns the
+    application navigation and the single shared <code>Containers</code> host.
+</p>
+
+<nav aria-label="Related task examples" class="example-actions">
+    <NavLink href="tasks/basic-input">Basic input</NavLink>
+    <NavLink href="tasks/data-grid">Data grid</NavLink>
+    <NavLink href="tasks/chart-dashboard">Chart dashboard</NavLink>
+</nav>
+
+<Button Text="Go to the overview"
+        Appearance="ButtonAppearance.Primary"
+        OnClick="@(() => Navigation.NavigateTo(""))" />

--- a/samples/Bluent.TaskExamples/Pages/Tasks/SimpleDiagram.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/SimpleDiagram.razor
@@ -1,0 +1,31 @@
+@page "/tasks/simple-diagram"
+
+<PageTitle>Simple diagram</PageTitle>
+
+<h1>Simple diagram using Bluent.UI.Diagrams</h1>
+
+<div class="diagram-frame">
+    <Diagram>
+        <ChildContent>
+            <rect x="30" y="70" width="150" height="60" rx="8"
+                  fill="var(--colorBrandBackground2)"
+                  stroke="var(--colorBrandStroke1)" />
+            <text x="70" y="105" fill="var(--colorNeutralForeground1)">
+                New order
+            </text>
+
+            <line x1="180" y1="100" x2="290" y2="100"
+                  stroke="var(--colorNeutralStroke1)"
+                  stroke-width="2" />
+            <path d="M 280 92 L 294 100 L 280 108 Z"
+                  fill="var(--colorNeutralStroke1)" />
+
+            <rect x="295" y="70" width="150" height="60" rx="8"
+                  fill="var(--colorPaletteGreenBackground2)"
+                  stroke="var(--colorPaletteGreenBorder1)" />
+            <text x="338" y="105" fill="var(--colorNeutralForeground1)">
+                Fulfilled
+            </text>
+        </ChildContent>
+    </Diagram>
+</div>

--- a/samples/Bluent.TaskExamples/Pages/Tasks/ThemeAndRtl.razor
+++ b/samples/Bluent.TaskExamples/Pages/Tasks/ThemeAndRtl.razor
@@ -1,0 +1,54 @@
+@page "/tasks/theme-rtl"
+@inject IBluentTheme Theme
+
+<PageTitle>Theme, dark mode, and RTL</PageTitle>
+
+<h1>Theme, dark mode, and RTL</h1>
+
+<div class="example-actions">
+    <Button Text="Light mode" OnClick="SetLightMode" />
+    <Button Text="Dark mode" OnClick="SetDarkMode" />
+    <Button Text="Default theme" OnClick="@(() => SetThemeFamily("default"))" />
+    <Button Text="Teams theme" OnClick="@(() => SetThemeFamily("teams"))" />
+    <Button Text="LTR" OnClick="SetLtr" />
+    <Button Text="RTL" OnClick="SetRtl" />
+</div>
+
+<MessageBar Type="MessageBarType.Information">
+    Current choice: @_status. Persist this preference in application code when
+    it must survive a reload.
+</MessageBar>
+
+@code {
+    private string _status = "light, default theme, LTR";
+
+    private async Task SetLightMode()
+    {
+        await Theme.SetLightThemeModeAsync();
+        _status = "light mode";
+    }
+
+    private async Task SetDarkMode()
+    {
+        await Theme.SetDarkThemeModeAsync();
+        _status = "dark mode";
+    }
+
+    private async Task SetThemeFamily(string family)
+    {
+        await Theme.SetThemeAsync(family);
+        _status = $"{family} theme";
+    }
+
+    private async Task SetLtr()
+    {
+        await Theme.SetLtrDirectionAsync();
+        _status = "LTR direction";
+    }
+
+    private async Task SetRtl()
+    {
+        await Theme.SetRtlDirectionAsync();
+        _status = "RTL direction";
+    }
+}

--- a/samples/Bluent.TaskExamples/Program.cs
+++ b/samples/Bluent.TaskExamples/Program.cs
@@ -1,0 +1,12 @@
+using Bluent.TaskExamples;
+using Bluent.UI.Extensions;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+builder.Services.AddBluentUI();
+
+await builder.Build().RunAsync();

--- a/samples/Bluent.TaskExamples/Shared/DrawerTaskContent.razor
+++ b/samples/Bluent.TaskExamples/Shared/DrawerTaskContent.razor
@@ -1,0 +1,16 @@
+<div class="p-4">
+    <Checkbox @bind-Value="_includeArchived" Label="Include archived orders" />
+
+    <div class="example-actions">
+        <Button Text="Apply"
+                Appearance="ButtonAppearance.Primary"
+                OnClick="@(() => Drawer?.Close(_includeArchived ? "Archived included" : "Active only"))" />
+        <Button Text="Cancel" OnClick="@(() => Drawer?.Close())" />
+    </div>
+</div>
+
+@code {
+    [CascadingParameter] public Drawer? Drawer { get; set; }
+
+    private bool _includeArchived;
+}

--- a/samples/Bluent.TaskExamples/Validation/InvalidTaskExample.cs.invalid
+++ b/samples/Bluent.TaskExamples/Validation/InvalidTaskExample.cs.invalid
@@ -1,0 +1,8 @@
+namespace Bluent.TaskExamples.Validation;
+
+// Included only when ValidateInvalidTaskExample=true. The Quality workflow
+// expects compilation to fail and name this file in its diagnostics.
+internal sealed class InvalidTaskExample
+{
+    private Bluent.UI.Components.ComponentThatDoesNotExist _component = default!;
+}

--- a/samples/Bluent.TaskExamples/_Imports.razor
+++ b/samples/Bluent.TaskExamples/_Imports.razor
@@ -1,0 +1,15 @@
+@using System.ComponentModel.DataAnnotations
+@using Bluent.TaskExamples
+@using Bluent.TaskExamples.Layout
+@using Bluent.TaskExamples.Shared
+@using Bluent.UI.Charts.ChartJs
+@using Bluent.UI.Charts.Components
+@using Bluent.UI.Components
+@using Bluent.UI.Components.DrawerComponent
+@using Bluent.UI.Diagrams.Components
+@using Bluent.UI.Interops.Abstractions
+@using Bluent.UI.Services.Abstractions
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization

--- a/samples/Bluent.TaskExamples/wwwroot/index.html
+++ b/samples/Bluent.TaskExamples/wwwroot/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en" data-bui-theme="light" dir="ltr">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bluent task examples</title>
+    <base href="/" />
+    <link href="_content/Bluent.UI/bluent.ui.theme.default.min.css" rel="stylesheet" />
+    <link href="_content/Bluent.UI/bluent.ui.components.min.css" rel="stylesheet" />
+    <link href="_content/Bluent.UI.Diagrams/bluent.ui.diagrams.min.css" rel="stylesheet" />
+    <style>
+        body {
+            margin: 0;
+        }
+
+        .app-header {
+            border-bottom: 1px solid var(--colorNeutralStroke2);
+            padding: 1rem 1.5rem;
+        }
+
+        .app-header a {
+            color: var(--colorNeutralForeground1);
+            font-size: 1.1rem;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .app-shell {
+            display: grid;
+            grid-template-columns: minmax(13rem, 18rem) minmax(0, 1fr);
+            min-height: calc(100vh - 3.5rem);
+        }
+
+        .app-shell nav {
+            border-inline-end: 1px solid var(--colorNeutralStroke2);
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+            padding: 1rem;
+        }
+
+        .app-shell nav a {
+            border-radius: 0.25rem;
+            color: var(--colorNeutralForeground1);
+            padding: 0.5rem 0.75rem;
+            text-decoration: none;
+        }
+
+        .app-shell nav a.active {
+            background: var(--colorNeutralBackground1Selected);
+            color: var(--colorBrandForeground1);
+        }
+
+        .app-shell main {
+            max-width: 64rem;
+            padding: 1.5rem;
+        }
+
+        .example-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-block: 1rem;
+        }
+
+        .example-field {
+            display: grid;
+            gap: 0.35rem;
+            margin-block: 1rem;
+            max-width: 30rem;
+        }
+
+        .diagram-frame {
+            border: 1px solid var(--colorNeutralStroke1);
+            height: 16rem;
+            max-width: 42rem;
+        }
+
+        @media (max-width: 48rem) {
+            .app-shell {
+                grid-template-columns: 1fr;
+            }
+
+            .app-shell nav {
+                border-block-end: 1px solid var(--colorNeutralStroke2);
+                border-inline-end: 0;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div id="app">Loading task examples…</div>
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+    </div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/scripts/quality/check_task_examples.sh
+++ b/scripts/quality/check_task_examples.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project="samples/Bluent.TaskExamples/Bluent.TaskExamples.csproj"
+invalid_log="$(mktemp -t bluent-invalid-task-example.XXXXXX)"
+trap 'rm -f "$invalid_log"' EXIT
+
+echo "Building canonical task examples..."
+dotnet build "$project" \
+  --configuration Release \
+  --no-restore \
+  -warnaserror
+
+echo "Verifying that an invalid example is rejected..."
+if dotnet build "$project" \
+  --configuration Release \
+  --no-restore \
+  -warnaserror \
+  -p:ValidateInvalidTaskExample=true \
+  >"$invalid_log" 2>&1; then
+  cat "$invalid_log"
+  echo "Expected the deliberately invalid task example to fail compilation." >&2
+  exit 1
+fi
+
+if ! grep -Fq "InvalidTaskExample.cs.invalid" "$invalid_log"; then
+  cat "$invalid_log"
+  echo "The negative control failed without identifying its source file." >&2
+  exit 1
+fi
+
+grep -F "InvalidTaskExample.cs.invalid" "$invalid_log"
+echo "Task examples compiled, and the negative control was rejected with a focused diagnostic."


### PR DESCRIPTION
## User-visible outcome

Adds ten canonical, task-oriented Bluent examples that developers and coding assistants can reuse without relying on unchecked Markdown snippets. The examples cover form input, validation, confirmation, feedback, DataGrid paging, navigation and layout, Drawer and Popover interaction, Charts, Diagrams, and theme/dark-mode/RTL behavior.

## Source and documentation changes

- Adds the standalone `samples/Bluent.TaskExamples` Blazor WebAssembly consumer with explicit package references, imports, service registration, shared overlay containers, and static assets.
- Adds task documentation under `docs/examples/tasks`, with package, namespace, setup, expected behavior, common mistakes, render-mode notes, and direct links to the compiled source.
- Adds the sample project to `Bluent.sln`.
- Updates the documentation indexes, `llms.txt`, contributor guidance, changelog, and Sprint 4 project tracking.
- Ignores macOS `.DS_Store` metadata repository-wide.

## Compilation and drift protection

Quality CI now runs `scripts/quality/check_task_examples.sh`. It builds all canonical examples in Release with warnings treated as errors, then enables an intentionally invalid opt-in source and requires compilation to fail with a diagnostic naming that source. Documentation links to the canonical source instead of maintaining a divergent runnable copy.

## Validation run locally

Environment: macOS 26.5.2, Apple Silicon, .NET SDK 10.0.300.

- `dotnet tool restore` — passed.
- `dotnet restore Bluent.sln` — passed.
- `bash scripts/quality/check_task_examples.sh` — valid consumer passed with 0 warnings and 0 errors; negative control failed as required with `CS0234` and named `InvalidTaskExample.cs.invalid`.
- `python3 scripts/quality/check_markdown_links.py` — passed across 48 Markdown files.
- `dotnet build Bluent.sln --configuration Release --no-restore -warnaserror` — passed with 0 warnings and 0 errors.
- `dotnet test Bluent.sln --configuration Release --no-build` — passed 19/19.
- `python3 -m unittest -v scripts/release/test_release_tools.py` — passed 13/13.
- Workflow YAML parsing and `git diff --check` — passed.

## Limits and risk

No public API or package boundary changes are included. Browser interaction, visual review, deployment, package publication, tags, and releases were not run or claimed. Issues #393 and #394 remain separate.

Closes #391
Closes #392