### PR TITLE
Prepare Bluent 1.0.368 release

### DIFF
--- a/.bluent/PROJECT.md
+++ b/.bluent/PROJECT.md
@@ -28,14 +28,14 @@ It tracks completed work, active work, upcoming work, and the working agreement 
 
 ## Package static-asset regression follow-up
 
-- A local, unreleased fix prevents generated unminified stylesheets from being
+- Release `1.0.368` prevents generated unminified stylesheets from being
   packed as consumer-owned `contentFiles` by `Bluent.UI` and
   `Bluent.UI.Diagrams`.
 - The Release solution build, five-package build-without-rebuilding sequence,
   package-content validator, 19 application tests, and a two-Razor-library
   consumer reproduction pass locally on Windows with .NET SDK `10.0.300`.
-- No package, tag, GitHub Release, or external change was published. Consumers
-  of `1.0.367` can exclude the package's `contentFiles` assets as a workaround.
+- Consumers remaining on `1.0.367` can exclude the package's `contentFiles`
+  assets as a workaround.
 
 ## Working Agreement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ for example `[Bluent.UI.Charts]`. Breaking changes must start with
 
 ### Added
 
+- None.
+
+### Changed
+
+- None.
+
+### Deprecated
+
+- None.
+
+### Removed
+
+- None.
+
+### Fixed
+
+- None.
+
+### Security
+
+- None.
+
+## [1.0.368] - 2026-08-17
+
+Applications should update directly installed Bluent packages together. This
+release preserves the documented minified static-asset paths and requires no
+public API migration.
+
+### Added
+
 - A standalone OrderDesk production-pattern reference application with
   customer and order workflows, validation, confirmation, feedback, filtering,
   charting, a lifecycle diagram, light/dark themes, and RTL.


### PR DESCRIPTION
## Outcome

Finalizes the accumulated `Unreleased` changes as stable release `1.0.368` dated 2026-08-17 and leaves a fresh, category-complete `Unreleased` section.

## Release scope

- `Bluent.UI` and `Bluent.UI.Diagrams` package fix preventing generated unminified CSS from entering NuGet `contentFiles`
- canonical task examples and OrderDesk reference application
- AI-readiness benchmark updates
- DrawerContent naming-collision guidance

The package fix preserves the documented minified static-asset paths and requires no public API migration. Consumers remaining on `1.0.367` can use `ExcludeAssets="contentFiles"` as a workaround.

## Validation

- `dotnet restore Bluent.sln` — passed
- Release solution build with warnings as errors — passed, 0 warnings and 0 errors
- Release solution tests — passed, 19/19
- release-tool unit tests — passed, 14/14
- exact `1.0.368` release-note extraction — passed
- NuGet preflight — all five `1.0.368` package IDs unused
- exact five-package local pack and validation at commit `11fb6d8` — passed
- `git diff --check` — passed

`dotnet tool restore` reported that this repository has no local tool manifest; no tool restore is claimed or required by the current build.